### PR TITLE
LRA-847-lsa-evaluate-letter-opener-config-on-dev-and-staging-environment

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
+  prepend_view_path "app/views/mailers"
   default from: "from@example.com"
   layout "mailer"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,10 +36,18 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  config.action_mailer.perform_caching = false
+  host = 'http://localhost:3000'
+  # on staging use host = 'http://STAGING SERVER NAME'
+    config.action_mailer.default_url_options = { host: host }
+  
+    # Don't care if the mailer can't send.
+    config.action_mailer.raise_delivery_errors = true
+  
+    config.action_mailer.perform_caching = false
+  
+    #letter_opener settings
+    config.action_mailer.delivery_method = :letter_opener_web
+    config.action_mailer.perform_deliveries = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -62,11 +62,18 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "lsa_evaluate_staging"
 
+  host = 'https://evaluate-staging.lsa.umich.edu/'
+
+  config.action_mailer.default_url_options = { host: host }
+
+  # Don't care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = true
+
   config.action_mailer.perform_caching = false
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  #letter_opener settings
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,9 @@ Rails.application.routes.draw do
 
 # Place this at the very end of the file to catch all undefined routes
   get '*path', to: 'application#render_404', via: :all
+
+  if Rails.env.development? || Rails.env.staging?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
+
 end


### PR DESCRIPTION
If you make one small tweak to your ApplicationMailer, you can achieve a more scannable folder structure. It is one extra level of folder nesting, but now you have a specific app/views/mailers folder instead of mixing in mailer views with controller views.