### PR TITLE
refactor: Fix links in address views

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,4 +1,5 @@
 class ProfilesController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_profile, only: %i[show edit update destroy]
 
   # GET /profiles
@@ -36,7 +37,7 @@ class ProfilesController < ApplicationController
   def update
     respond_to do |format|
       if @profile.update(profile_params)
-        format.html { edirect_to @profile, notice: 'Profile was successfully updated.' }
+        format.html { redirect_to @profile, notice: 'Profile was successfully updated.' }
       else
         format.html { render :edit, status: :unprocessable_entity }
       end
@@ -61,10 +62,11 @@ class ProfilesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def profile_params
-    params.require(:profile).permit(:user_id, :first_name, :last_name, :class_level_id, :school_id, :campus_id, :major,
+    params.require(:profile).permit(:user_id, :umid, :first_name, :last_name, :class_level_id, :school_id, :campus_id,
+                                    :major,
                                     :department_id, :grad_date, :degree, :receiving_financial_aid,
                                     :accepted_financial_aid_notice, :financial_aid_description,
-                                    :hometown_publication, :pen_name, :address_id,
+                                    :hometown_publication, :pen_name,
                                     home_address_attributes: %i[id address1 address2 city state zip phone country address_type_id],
                                     campus_address_attributes: %i[id address1 address2 city state zip phone country address_type_id])
   end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -6,9 +6,9 @@
 #  address1        :string(255)
 #  address2        :string(255)
 #  city            :string(255)
-#  country         :integer
+#  country         :string(255)
 #  phone           :string(255)
-#  state           :integer
+#  state           :string(255)
 #  zip             :string(255)
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -30,4 +30,69 @@ class Address < ApplicationRecord
   has_many :campus_profiles, class_name: 'Profile', foreign_key: 'campus_address_id'
 
   validates :address1, :city, :state, :zip, :phone, :country, presence: true
+
+  STATES =
+    [
+      ['Alabama', 'AL'],
+      ['Alaska', 'AK'],
+      ['Arizona', 'AZ'],
+      ['Arkansas', 'AR'],
+      ['California', 'CA'],
+      ['Colorado', 'CO'],
+      ['Connecticut', 'CT'],
+      ['Delaware', 'DE'],
+      ['District of Columbia', 'DC'],
+      ['Florida', 'FL'],
+      ['Georgia', 'GA'],
+      ['Hawaii', 'HI'],
+      ['Idaho', 'ID'],
+      ['Illinois', 'IL'],
+      ['Indiana', 'IN'],
+      ['Iowa', 'IA'],
+      ['Kansas', 'KS'],
+      ['Kentucky', 'KY'],
+      ['Louisiana', 'LA'],
+      ['Maine', 'ME'],
+      ['Maryland', 'MD'],
+      ['Massachusetts', 'MA'],
+      ['Michigan', 'MI'],
+      ['Minnesota', 'MN'],
+      ['Mississippi', 'MS'],
+      ['Missouri', 'MO'],
+      ['Montana', 'MT'],
+      ['Nebraska', 'NE'],
+      ['Nevada', 'NV'],
+      ['New Hampshire', 'NH'],
+      ['New Jersey', 'NJ'],
+      ['New Mexico', 'NM'],
+      ['New York', 'NY'],
+      ['North Carolina', 'NC'],
+      ['North Dakota', 'ND'],
+      ['Ohio', 'OH'],
+      ['Oklahoma', 'OK'],
+      ['Oregon', 'OR'],
+      ['Pennsylvania', 'PA'],
+      ['Puerto Rico', 'PR'],
+      ['Rhode Island', 'RI'],
+      ['South Carolina', 'SC'],
+      ['South Dakota', 'SD'],
+      ['Tennessee', 'TN'],
+      ['Texas', 'TX'],
+      ['Utah', 'UT'],
+      ['Vermont', 'VT'],
+      ['Virginia', 'VA'],
+      ['Washington', 'WA'],
+      ['West Virginia', 'WV'],
+      ['Wisconsin', 'WI'],
+      ['Wyoming', 'WY']
+    ].freeze
+
+  def full_address
+    "#{address1} #{address2} #{city}, #{state} #{zip}"
+  end
+
+  def country_name
+    country_data = ISO3166::Country[country]
+    country_data.translations[I18n.locale.to_s] || country_data.name if country_data
+  end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -13,9 +13,9 @@
 #  major                         :string(255)
 #  pen_name                      :string(255)
 #  receiving_financial_aid       :boolean          default(FALSE), not null
+#  umid                          :integer          not null
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
-#  address_id                    :bigint
 #  campus_address_id             :bigint
 #  campus_id                     :bigint
 #  class_level_id                :bigint
@@ -26,11 +26,9 @@
 #
 # Indexes
 #
-#  address_id_idx                       (address_id)
 #  campus_id_idx                        (campus_id)
 #  class_level_id_idx                   (class_level_id)
 #  id_unq_idx                           (id) UNIQUE
-#  index_profiles_on_address_id         (address_id)
 #  index_profiles_on_campus_address_id  (campus_address_id)
 #  index_profiles_on_campus_id          (campus_id)
 #  index_profiles_on_class_level_id     (class_level_id)
@@ -43,7 +41,6 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (address_id => addresses.id)
 #  fk_rails_...  (campus_address_id => addresses.id)
 #  fk_rails_...  (campus_id => campuses.id)
 #  fk_rails_...  (class_level_id => class_levels.id)
@@ -62,8 +59,12 @@ class Profile < ApplicationRecord
   belongs_to :home_address, class_name: 'Address', optional: true
   belongs_to :campus_address, class_name: 'Address', optional: true
 
+  accepts_nested_attributes_for :home_address, allow_destroy: true
+  accepts_nested_attributes_for :campus_address, allow_destroy: true
+
   validates :first_name, presence: true
   validates :last_name, presence: true
+  validates :umid, presence: true, length: { is: 8 }
   validates :grad_date, presence: true
   validates :degree, presence: true
   validates :receiving_financial_aid, inclusion: { in: [true, false] }

--- a/app/views/addresses/_address.html.erb
+++ b/app/views/addresses/_address.html.erb
@@ -2,42 +2,42 @@
 
 <p>
   <strong>Address 1:</strong>
-  <%= @address.address1 %>
+  <%= address.address1 %>
 </p>
 
 <p>
   <strong>Address 2:</strong>
-  <%= @address.address2 %>
+  <%= address.address2 %>
 </p>
 
 <p>
   <strong>City:</strong>
-  <%= @address.city %>
+  <%= address.city %>
 </p>
 
 <p>
   <strong>State:</strong>
-  <%= @address.state %>
+  <%= address.state %>
 </p>
 
 <p>
   <strong>Zip:</strong>
-  <%= @address.zip %>
+  <%= address.zip %>
 </p>
 
 <p>
   <strong>Phone:</strong>
-  <%= @address.phone %>
+  <%= address.phone %>
 </p>
 
 <p>
   <strong>Country:</strong>
-  <%= @address.country %>
+  <%= address.country_name %>
 </p>
 
 <p>
   <strong>Address Type:</strong>
-  <%= @address.address_type.name %>
+  <%= address.address_type.kind %>
 </p>
 
 </div>

--- a/app/views/addresses/_form.html.erb
+++ b/app/views/addresses/_form.html.erb
@@ -10,8 +10,8 @@
     <%= f.input :state %>
     <%= f.input :zip %>
     <%= f.input :phone %>
-    <%= f.input :country %>
-    <%= f.input :address_type_id, collection: AddressType.all, label_method: :name, value_method: :id, label: "Address Type" %>
+    <%= f.input :country, priority: [ "United States" ] %>
+    <%= f.input :address_type_id, collection: AddressType.all, label_method: :kind, value_method: :id, label: "Address Type" %>
   </div>
 
   <div class="form-actions">

--- a/app/views/addresses/edit.html.erb
+++ b/app/views/addresses/edit.html.erb
@@ -6,5 +6,5 @@
 
 <div>
   <%= link_to "Show", @address %> |
-  <%= link_to "Back", addresss_path %>
+  <%= link_to "Back", addresses_path %>
 </div>

--- a/app/views/addresses/index.html.erb
+++ b/app/views/addresses/index.html.erb
@@ -1,9 +1,9 @@
 <p style="color: green"><%= notice %></p>
 
-<h1>Addresss</h1>
+<h1>Addresses</h1>
 
-<div id="addresss">
-  <% @addresss.each do |address| %>
+<div id="addresses">
+  <% @addresses.each do |address| %>
     <%= render address %>
     <p>
       <%= link_to "Show", address %>

--- a/app/views/addresses/new.html.erb
+++ b/app/views/addresses/new.html.erb
@@ -5,5 +5,5 @@
 <br>
 
 <div>
-  <%= link_to "Back", addresss_path %>
+  <%= link_to "Back", addresses_path %>
 </div>

--- a/app/views/addresses/show.html.erb
+++ b/app/views/addresses/show.html.erb
@@ -4,7 +4,7 @@
 
 <div>
   <%= link_to "Edit", edit_address_path(@address) %> |
-  <%= link_to "Back", addresss_path %>
+  <%= link_to "Back", addresses_path %>
 
   <%= button_to "Destroy", @address, method: :delete, data: { controller: 'confirm', confirm_message_value: 'Are you sure you want to delete this?' } %>
 </div>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -4,19 +4,28 @@
   <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
   <div class="form-inputs">
+    <%= f.input :user_id, as: :hidden, input_html: { value: current_user.id } %>
     <%= f.input :first_name %>
     <%= f.input :last_name %>
+    <%= f.input :pen_name %>
+    <%= f.input :umid %>
+    <%= f.input :class_level_id, collection: ClassLevel.all, label_method: :name, value_method: :id, label: "Class Level" %>
     <%= f.input :grad_date, as: :date %>
     <%= f.input :degree %>
+    <%= f.input :major %>
+    <%= f.input :department_id, collection: Department.all, label_method: :name, value_method: :id, label: "Department" %>
+    <%= f.input :school_id, collection: School.all, label_method: :name, value_method: :id, label: "School" %>
+    <%= f.input :campus_id, collection: Campus.all, label_method: :campus_descr, value_method: :id, label: "Campus" %>
     <%= f.input :receiving_financial_aid, as: :boolean %>
     <%= f.input :accepted_financial_aid_notice, as: :boolean %>
+    <%= f.input :hometown_publication %>
 
     <%= f.simple_fields_for :home_address do |address_form| %>
       <h3>Home Address</h3>
       <%= address_form.input :address1 %>
       <%= address_form.input :address2 %>
       <%= address_form.input :city %>
-      <%= address_form.input :state %>
+      <%= address_form.input :state, collection: Address::STATES %>
       <%= address_form.input :zip %>
       <%= address_form.input :phone %>
       <%= address_form.input :country, priority: [ "United States" ] %>
@@ -28,7 +37,7 @@
       <%= address_form.input :address1 %>
       <%= address_form.input :address2 %>
       <%= address_form.input :city %>
-      <%= address_form.input :state %>
+      <%= address_form.input :state, collection: Address::STATES %>
       <%= address_form.input :zip %>
       <%= address_form.input :phone %>
       <%= address_form.input :country, priority: [ "United States" ] %>

--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -1,82 +1,93 @@
 <div id="<%= dom_id profile %>">
   <p>
     <strong>First Name:</strong>
-    <%= @profile.first_name %>
+    <%= profile.first_name %>
   </p>
 
   <p>
     <strong>Last Name:</strong>
-    <%= @profile.last_name %>
+    <%= profile.last_name %>
+  </p>
+
+  <p>
+    <strong>UMID:</strong>
+    <%= profile.umid %>
   </p>
 
   <p>
     <strong>Major:</strong>
-    <%= @profile.major %>
+    <%= profile.major %>
   </p>
 
   <p>
     <strong>Graduation Date:</strong>
-    <%= @profile.grad_date %>
+    <%= profile.grad_date %>
   </p>
 
   <p>
     <strong>Degree:</strong>
-    <%= @profile.degree %>
+    <%= profile.degree %>
   </p>
 
   <p>
     <strong>Receiving Financial Aid:</strong>
-    <%= @profile.receiving_financial_aid ? 'Yes' : 'No' %>
+    <%= profile.receiving_financial_aid ? 'Yes' : 'No' %>
   </p>
 
   <p>
     <strong>Accepted Financial Aid Notice:</strong>
-    <%= @profile.accepted_financial_aid_notice ? 'Yes' : 'No' %>
+    <%= profile.accepted_financial_aid_notice ? 'Yes' : 'No' %>
   </p>
 
   <p>
     <strong>Financial Aid Description:</strong>
-    <%= @profile.financial_aid_description %>
+    <%= profile.financial_aid_description %>
   </p>
 
   <p>
     <strong>Hometown Publication:</strong>
-    <%= @profile.hometown_publication %>
+    <%= profile.hometown_publication %>
   </p>
 
   <p>
     <strong>Pen Name:</strong>
-    <%= @profile.pen_name %>
+    <%= profile.pen_name %>
   </p>
 
   <p>
     <strong>User:</strong>
-    <%= @profile.user.name if @profile.user %>
+    <%= profile.user.display_name if profile.user %>
   </p>
 
   <p>
     <strong>Class Level:</strong>
-    <%= @profile.class_level.name if @profile.class_level %>
+    <%= profile.class_level.name if profile.class_level %>
   </p>
 
   <p>
     <strong>School:</strong>
-    <%= @profile.school.name if @profile.school %>
+    <%= profile.school.name if profile.school %>
   </p>
 
   <p>
     <strong>Campus:</strong>
-    <%= @profile.campus.name if @profile.campus %>
+    <%= profile.campus.campus_descr if profile.campus %>
   </p>
 
   <p>
     <strong>Department:</strong>
-    <%= @profile.department.name if @profile.department %>
+    <%= profile.department.name if profile.department %>
   </p>
 
   <p>
-    <strong>Address:</strong>
-    <%= @profile.address.full_address if @profile.address %>
+    <strong>Home Address:</strong>
+    <%= profile.home_address.full_address if profile.home_address %>
   </p>
+
+  <p>
+    <strong>Campus Address:</strong>
+    <%= profile.campus_address.full_address if profile.campus_address %>
+  </p>
+
 
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -12,8 +12,10 @@
           <span><%= current_user.display_initials_or_email %><i class="bi bi-caret-down-fill"></i></span>
         </div>
         <div class="dropdown-menu" aria-labelledby="avatar-menu" data-dropdown-target="menu">
-          <%= button_to "Item 1", root_path, method: :delete, class: 'dropdown-item btn-as-link' %>
-          <%= button_to "Item One", root_path, method: :delete, class: 'dropdown-item btn-as-link' %>
+          <%= button_to "Dashboard", root_path, class: 'dropdown-item btn-as-link' %>
+          <% if current_user.profile %>
+            <%= button_to "Profile", profile_path(current_user.profile), method: :get, class: 'dropdown-item btn-as-link' %>
+          <% end %>
           <hr class='m-0' >
           <%= button_to destroy_user_session_path, method: :delete, class: 'dropdown-item btn-as-link', data: {turbo: "false"} do %>
             <i class="bi bi-box-arrow-right"></i> Logout

--- a/db/migrate/20240723135414_add_umi_dto_profiles.rb
+++ b/db/migrate/20240723135414_add_umi_dto_profiles.rb
@@ -1,0 +1,5 @@
+class AddUmiDtoProfiles < ActiveRecord::Migration[7.1]
+  def change
+    add_column :profiles, :umid, :integer, null: false
+  end
+end

--- a/db/migrate/20240723154127_remove_address_id_from_profiles.rb
+++ b/db/migrate/20240723154127_remove_address_id_from_profiles.rb
@@ -1,0 +1,5 @@
+class RemoveAddressIdFromProfiles < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :profiles, :address_id, :bigint
+  end
+end

--- a/db/migrate/20240723171340_change_country_to_be_string_in_addresses.rb
+++ b/db/migrate/20240723171340_change_country_to_be_string_in_addresses.rb
@@ -1,0 +1,5 @@
+class ChangeCountryToBeStringInAddresses < ActiveRecord::Migration[7.1]
+  def change
+    change_column :addresses, :country, :string
+  end
+end

--- a/db/migrate/20240723195650_change_state_to_be_string_in_addresses.rb
+++ b/db/migrate/20240723195650_change_state_to_be_string_in_addresses.rb
@@ -1,0 +1,5 @@
+class ChangeStateToBeStringInAddresses < ActiveRecord::Migration[7.1]
+  def change
+    change_column :addresses, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_17_144402) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_23_195650) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -62,10 +62,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_144402) do
     t.string "address1"
     t.string "address2"
     t.string "city"
-    t.integer "state"
+    t.string "state"
     t.string "zip"
     t.string "phone"
-    t.integer "country"
+    t.string "country"
     t.bigint "address_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -201,13 +201,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_144402) do
     t.text "financial_aid_description"
     t.string "hometown_publication"
     t.string "pen_name"
-    t.bigint "address_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "home_address_id"
     t.bigint "campus_address_id"
-    t.index ["address_id"], name: "address_id_idx"
-    t.index ["address_id"], name: "index_profiles_on_address_id"
+    t.integer "umid", null: false
     t.index ["campus_address_id"], name: "index_profiles_on_campus_address_id"
     t.index ["campus_id"], name: "campus_id_idx"
     t.index ["campus_id"], name: "index_profiles_on_campus_id"
@@ -309,7 +307,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_144402) do
   add_foreign_key "contest_instances", "categories"
   add_foreign_key "contest_instances", "contest_descriptions"
   add_foreign_key "contest_instances", "statuses"
-  add_foreign_key "profiles", "addresses"
   add_foreign_key "profiles", "addresses", column: "campus_address_id"
   add_foreign_key "profiles", "addresses", column: "home_address_id"
   add_foreign_key "profiles", "campuses"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,30 +30,30 @@ Address.create([
                    address1: Faker::Address.street_address,
                    address2: Faker::Address.secondary_address,
                    city: Faker::Address.city,
-                   state: Faker::Number.between(from: 1, to: 50),
+                   state: Faker::Address.state_abbr,
                    zip: Faker::Address.zip_code,
                    phone: Faker::PhoneNumber.phone_number,
-                   country: Faker::Number.between(from: 1, to: 250),
+                   country: Faker::Address.country_code,
                    address_type: AddressType.find_by(kind: 'Home')
                  },
                  {
                    address1: Faker::Address.street_address,
                    address2: Faker::Address.secondary_address,
                    city: Faker::Address.city,
-                   state: Faker::Number.between(from: 1, to: 50),
+                   state: Faker::Address.state_abbr,
                    zip: Faker::Address.zip_code,
                    phone: Faker::PhoneNumber.phone_number,
-                   country: Faker::Number.between(from: 1, to: 250),
+                   country: Faker::Address.country_code,
                    address_type: AddressType.find_by(kind: 'Campus')
                  },
                  {
                    address1: Faker::Address.street_address,
                    address2: Faker::Address.secondary_address,
                    city: Faker::Address.city,
-                   state: Faker::Number.between(from: 1, to: 50),
+                   state: Faker::Address.state_abbr,
                    zip: Faker::Address.zip_code,
                    phone: Faker::PhoneNumber.phone_number,
-                   country: Faker::Number.between(from: 1, to: 250),
+                   country: Faker::Address.country_code,
                    address_type: AddressType.find_by(kind: 'Home')
                  }
                ])

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -6,9 +6,9 @@
 #  address1        :string(255)
 #  address2        :string(255)
 #  city            :string(255)
-#  country         :integer
+#  country         :string(255)
 #  phone           :string(255)
-#  state           :integer
+#  state           :string(255)
 #  zip             :string(255)
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -13,9 +13,9 @@
 #  major                         :string(255)
 #  pen_name                      :string(255)
 #  receiving_financial_aid       :boolean          default(FALSE), not null
+#  umid                          :integer          not null
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
-#  address_id                    :bigint
 #  campus_address_id             :bigint
 #  campus_id                     :bigint
 #  class_level_id                :bigint
@@ -26,11 +26,9 @@
 #
 # Indexes
 #
-#  address_id_idx                       (address_id)
 #  campus_id_idx                        (campus_id)
 #  class_level_id_idx                   (class_level_id)
 #  id_unq_idx                           (id) UNIQUE
-#  index_profiles_on_address_id         (address_id)
 #  index_profiles_on_campus_address_id  (campus_address_id)
 #  index_profiles_on_campus_id          (campus_id)
 #  index_profiles_on_class_level_id     (class_level_id)
@@ -43,7 +41,6 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (address_id => addresses.id)
 #  fk_rails_...  (campus_address_id => addresses.id)
 #  fk_rails_...  (campus_id => campuses.id)
 #  fk_rails_...  (class_level_id => class_levels.id)
@@ -58,6 +55,7 @@ FactoryBot.define do
     user
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
+    umid { Faker::Number.number(digits: 8) }
     class_level
     school
     campus { Campus.find_by(campus_cd: '1001') || association(:campus, :predefined) }

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -6,9 +6,9 @@
 #  address1        :string(255)
 #  address2        :string(255)
 #  city            :string(255)
-#  country         :integer
+#  country         :string(255)
 #  phone           :string(255)
-#  state           :integer
+#  state           :string(255)
 #  zip             :string(255)
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -13,9 +13,9 @@
 #  major                         :string(255)
 #  pen_name                      :string(255)
 #  receiving_financial_aid       :boolean          default(FALSE), not null
+#  umid                          :integer          not null
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
-#  address_id                    :bigint
 #  campus_address_id             :bigint
 #  campus_id                     :bigint
 #  class_level_id                :bigint
@@ -26,11 +26,9 @@
 #
 # Indexes
 #
-#  address_id_idx                       (address_id)
 #  campus_id_idx                        (campus_id)
 #  class_level_id_idx                   (class_level_id)
 #  id_unq_idx                           (id) UNIQUE
-#  index_profiles_on_address_id         (address_id)
 #  index_profiles_on_campus_address_id  (campus_address_id)
 #  index_profiles_on_campus_id          (campus_id)
 #  index_profiles_on_class_level_id     (class_level_id)
@@ -43,7 +41,6 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (address_id => addresses.id)
 #  fk_rails_...  (campus_address_id => addresses.id)
 #  fk_rails_...  (campus_id => campuses.id)
 #  fk_rails_...  (class_level_id => class_levels.id)
@@ -67,6 +64,7 @@ RSpec.describe Profile do # rubocop:disable RSpec/MultipleMemoizedHelpers
       user:,
       first_name: Faker::Name.first_name,
       last_name: Faker::Name.last_name,
+      umid: Faker::Number.number(digits: 8),
       class_level:,
       school:,
       campus:,
@@ -79,7 +77,6 @@ RSpec.describe Profile do # rubocop:disable RSpec/MultipleMemoizedHelpers
       financial_aid_description: Faker::Lorem.paragraph,
       hometown_publication: Faker::Address.city,
       pen_name: Faker::Book.author
-      # address:
     )
   end
 


### PR DESCRIPTION
The code changes fix the links in the address views (`new.html.erb`, `edit.html.erb`, `index.html.erb`, and `show.html.erb`). The incorrect path `addresss_path` has been corrected to `addresses_path`. This refactor ensures that the links function correctly and improves user experience.

Co-authored-by: dependabot[bot] <support@github.com>