### PR TITLE
Lra 1009 lsa evaluate a means to archive rather than delete contest descriptions and contest instances

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,8 +17,8 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
-  rescue_from ActiveRecord::RecordNotFound, with: :render404
-  rescue_from StandardError, with: :render500
+  # rescue_from ActiveRecord::RecordNotFound, with: :render404
+  # rescue_from StandardError, with: :render500
 
   def redirect_back_or_default(notice: '', alert: false, default: root_url)
     if alert

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,17 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :render404
   rescue_from StandardError, with: :render500
 
+  def redirect_back_or_default(notice: '', alert: false, default: root_url)
+    if alert
+      flash[:alert] = notice
+    else
+      flash[:notice] = notice
+    end
+    url = session[:return_to]
+    session[:return_to] = nil
+    redirect_to(url, anchor: "top" || default)
+  end
+
   def render404
     respond_to do |format|
       format.html { render 'errors/not_found', status: :not_found, layout: 'application' }

--- a/app/controllers/contest_descriptions_controller.rb
+++ b/app/controllers/contest_descriptions_controller.rb
@@ -1,6 +1,6 @@
 class ContestDescriptionsController < ApplicationController
   before_action :set_container
-  before_action :set_contest_description, only: %i[show edit update destroy]
+  before_action :set_contest_description, only: %i[show edit update archive unarchive]
 
   def index
     @contest_descriptions = ContestDescription.all
@@ -36,11 +36,17 @@ class ContestDescriptionsController < ApplicationController
     end
   end
 
-  def destroy
-    @contest_description.destroy
+  def archive
+    session[:return_to] = request.referer
+    if @contest_description.update(archived: true)
+      redirect_back_or_default(notice: "The contest description was archived")
+    end
+  end
 
-    respond_to do |format|
-      format.html { redirect_to containers_path, notice: 'Contest description was successfully destroyed.' }
+  def unarchive
+    session[:return_to] = request.referer
+    if @contest_description.update(archived: false)
+      redirect_back_or_default(notice: "The contest description was unarchived")
     end
   end
 

--- a/app/controllers/contest_descriptions_controller.rb
+++ b/app/controllers/contest_descriptions_controller.rb
@@ -40,6 +40,10 @@ class ContestDescriptionsController < ApplicationController
     session[:return_to] = request.referer
     if @contest_description.update(archived: true)
       redirect_back_or_default(notice: "The contest description was archived")
+    else
+      @container = Container.find(params[:container_id])
+      @contest_descriptions = @container.contest_descriptions
+      redirect_back_or_default(notice: "Error archiving contest description", alert: true)
     end
   end
 
@@ -47,6 +51,10 @@ class ContestDescriptionsController < ApplicationController
     session[:return_to] = request.referer
     if @contest_description.update(archived: false)
       redirect_back_or_default(notice: "The contest description was unarchived")
+    else
+      @container = Container.find(params[:container_id])
+      @contest_descriptions = @container.contest_descriptions
+      redirect_back_or_default(notice: "Error unarchiving contest description", alert: true)
     end
   end
 

--- a/app/controllers/contest_instances_controller.rb
+++ b/app/controllers/contest_instances_controller.rb
@@ -1,7 +1,7 @@
 class ContestInstancesController < ApplicationController
   before_action :set_container
   before_action :set_contest_description
-  before_action :set_contest_instance, only: %i[show edit update destroy]
+  before_action :set_contest_instance, only: %i[show edit update archive unarchive]
 
   # GET /contest_instances
   def index
@@ -49,14 +49,17 @@ class ContestInstancesController < ApplicationController
     end
   end
 
-  # DELETE /contest_instances/:id
-  def destroy
-    @contest_instance.destroy
-    respond_to do |format|
-      format.html do
-        redirect_to container_contest_description_contest_instances_path(@container, @contest_description),
-                    notice: 'Contest instance was successfully destroyed.'
-      end
+  def archive
+    session[:return_to] = request.referer
+    if @contest_instance.update(archived: true)
+      redirect_back_or_default(notice: "The contest instance was archived")
+    end
+  end
+
+  def unarchive
+    session[:return_to] = request.referer
+    if @contest_instance.update(archived: false)
+      redirect_back_or_default(notice: "The contest instance was unarchived")
     end
   end
 

--- a/app/controllers/contest_instances_controller.rb
+++ b/app/controllers/contest_instances_controller.rb
@@ -53,6 +53,10 @@ class ContestInstancesController < ApplicationController
     session[:return_to] = request.referer
     if @contest_instance.update(archived: true)
       redirect_back_or_default(notice: "The contest instance was archived")
+    else
+      @container = Container.find(params[:container_id])
+      @contest_description = @container.contest_descriptions.find(params[:contest_description_id])
+      redirect_back_or_default(notice: "Error archiving contest instance", alert: true)
     end
   end
 
@@ -60,6 +64,10 @@ class ContestInstancesController < ApplicationController
     session[:return_to] = request.referer
     if @contest_instance.update(archived: false)
       redirect_back_or_default(notice: "The contest instance was unarchived")
+    else
+      @container = Container.find(params[:container_id])
+      @contest_description = @container.contest_descriptions.find(params[:contest_description_id])
+      redirect_back_or_default(notice: "Error unarchiving contest instance", alert: true)
     end
   end
 

--- a/app/views/containers/index.html.erb
+++ b/app/views/containers/index.html.erb
@@ -46,9 +46,9 @@
                       <%= link_to "View contest instances", container_contest_description_contest_instances_path(container, description), class: "link_to" %>
                       <% unless description.contest_instances.where(active: true).present? %>
                         <% if description.archived %>
-                          | <%= link_to "Unarchive", unarchive_contest_description_path(container, description), data: { turbo_confirm: "Are you sure you want to unarchive this contest description?", turbo_method: :post } %>
+                          | <%= link_to "Unarchive", unarchive_contest_description_container_contest_descriptions_path(container, description), data: { turbo_confirm: "Are you sure you want to unarchive this contest description?", turbo_method: :post } %>
                         <% else %>
-                          | <%= link_to "Archive", archive_contest_description_path(container, description), data: { turbo_confirm: "Are you sure you want to archive this contest description?", turbo_method: :post } %>
+                          | <%= link_to "Archive", archive_contest_description_container_contest_descriptions_path(container, description), data: { turbo_confirm: "Are you sure you want to archive this contest description?", turbo_method: :post } %>
                         <% end %>
                       <% end %>
                     </td>

--- a/app/views/containers/index.html.erb
+++ b/app/views/containers/index.html.erb
@@ -43,8 +43,14 @@
                     <td><%= description.short_name %></td>
                     <td><%= description.eligibility_rules %></td>
                     <td>
-                      <%= link_to "View contest instances", container_contest_description_contest_instances_path(container, description), class: "link_to" %> |
-                      <%= link_to "Archive", container_contest_description_path(container, description), data: { controller: 'confirm', confirm_message_value: 'Are you sure you want to archive this?' }, class: "link_to" %>
+                      <%= link_to "View contest instances", container_contest_description_contest_instances_path(container, description), class: "link_to" %>
+                      <% unless description.contest_instances.where(active: true).present? %>
+                        <% if description.archived %>
+                          | <%= link_to "Unarchive", unarchive_contest_description_path(container, description), data: { turbo_confirm: "Are you sure you want to unarchive this contest description?" , turbo_method: :post } %>
+                        <% else %>
+                          | <%= link_to "Archive", archive_contest_description_path(container, description), data: { turbo_confirm: "Are you sure you want to archive this contest description?" , turbo_method: :post } %>
+                        <% end %>
+                      <% end %>
                     </td>
                     </tr>
                   </tr>

--- a/app/views/containers/index.html.erb
+++ b/app/views/containers/index.html.erb
@@ -46,9 +46,9 @@
                       <%= link_to "View contest instances", container_contest_description_contest_instances_path(container, description), class: "link_to" %>
                       <% unless description.contest_instances.where(active: true).present? %>
                         <% if description.archived %>
-                          | <%= link_to "Unarchive", unarchive_contest_description_path(container, description), data: { turbo_confirm: "Are you sure you want to unarchive this contest description?" , turbo_method: :post } %>
+                          | <%= link_to "Unarchive", unarchive_contest_description_path(container, description), data: { turbo_confirm: "Are you sure you want to unarchive this contest description?", turbo_method: :post } %>
                         <% else %>
-                          | <%= link_to "Archive", archive_contest_description_path(container, description), data: { turbo_confirm: "Are you sure you want to archive this contest description?" , turbo_method: :post } %>
+                          | <%= link_to "Archive", archive_contest_description_path(container, description), data: { turbo_confirm: "Are you sure you want to archive this contest description?", turbo_method: :post } %>
                         <% end %>
                       <% end %>
                     </td>

--- a/app/views/contest_instances/show.html.erb
+++ b/app/views/contest_instances/show.html.erb
@@ -11,9 +11,9 @@
   <%= link_to "Edit", edit_container_contest_description_contest_instance_path(@container, @contest_description, @contest_instance), class: "btn btn-sm btn-primary" %>
   <% unless @contest_instance.active %>
     <% if @contest_instance.archived %>
-      | <%= link_to "Unarchive", unarchive_contest_instance_path(@container, @contest_description, @contest_instance), data: { turbo_confirm: "Are you sure you want to unarchive this contest instance?" , turbo_method: :post } %>
+      | <%= link_to "Unarchive", unarchive_contest_instance_path(@container, @contest_description, @contest_instance), data: { turbo_confirm: "Are you sure you want to unarchive this contest instance?", turbo_method: :post } %>
     <% else %>
-      | <%= link_to "Archive", archive_contest_instance_path(@container, @contest_description, @contest_instance), data: { turbo_confirm: "Are you sure you want to archive this contest instance?" , turbo_method: :post } %>
+      | <%= link_to "Archive", archive_contest_instance_path(@container, @contest_description, @contest_instance), data: { turbo_confirm: "Are you sure you want to archive this contest instance?", turbo_method: :post } %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/contest_instances/show.html.erb
+++ b/app/views/contest_instances/show.html.erb
@@ -8,7 +8,12 @@
   </div>
 </div>
 <div>
-  <%= link_to "Edit", edit_container_contest_description_contest_instance_path(@container, @contest_description, @contest_instance), class: "btn btn-sm btn-primary" %> |
-  
-  <%= link_to "Archive", container_contest_description_contest_instance_path(@container, @contest_description, @contest_instance), data: { controller: 'confirm', confirm_message_value: 'Are you sure you want to archive this?' } %>
+  <%= link_to "Edit", edit_container_contest_description_contest_instance_path(@container, @contest_description, @contest_instance), class: "btn btn-sm btn-primary" %>
+  <% unless @contest_instance.active %>
+    <% if @contest_instance.archived %>
+      | <%= link_to "Unarchive", unarchive_contest_instance_path(@container, @contest_description, @contest_instance), data: { turbo_confirm: "Are you sure you want to unarchive this contest instance?" , turbo_method: :post } %>
+    <% else %>
+      | <%= link_to "Archive", archive_contest_instance_path(@container, @contest_description, @contest_instance), data: { turbo_confirm: "Are you sure you want to archive this contest instance?" , turbo_method: :post } %>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/contest_instances/show.html.erb
+++ b/app/views/contest_instances/show.html.erb
@@ -11,9 +11,9 @@
   <%= link_to "Edit", edit_container_contest_description_contest_instance_path(@container, @contest_description, @contest_instance), class: "btn btn-sm btn-primary" %>
   <% unless @contest_instance.active %>
     <% if @contest_instance.archived %>
-      | <%= link_to "Unarchive", unarchive_contest_instance_path(@container, @contest_description, @contest_instance), data: { turbo_confirm: "Are you sure you want to unarchive this contest instance?", turbo_method: :post } %>
+      | <%= link_to "Unarchive", unarchive_contest_instance_container_contest_descriptions_path(@container, @contest_description, @contest_instance), data: { turbo_confirm: "Are you sure you want to unarchive this contest instance?", turbo_method: :post } %>
     <% else %>
-      | <%= link_to "Archive", archive_contest_instance_path(@container, @contest_description, @contest_instance), data: { turbo_confirm: "Are you sure you want to archive this contest instance?", turbo_method: :post } %>
+      | <%= link_to "Archive", archive_contest_instance_container_contest_descriptions_path(@container, @contest_description, @contest_instance), data: { turbo_confirm: "Are you sure you want to archive this contest instance?", turbo_method: :post } %>
     <% end %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,15 +12,21 @@ Rails.application.routes.draw do
 
   resources :containers do
     resources :contest_descriptions do
+      collection do
+        post 'archive_contest_description', to: 'contest_descriptions#archive'
+        post 'unarchive_contest_description', to: 'contest_descriptions#unarchive'
+        post 'archive_contest_instance', to: 'contest_instances#archive'
+        post 'unarchive_contest_instance', to: 'contest_instances#unarchive'
+      end
       resources :contest_instances, path: 'instances'
     end
     resources :assignments, only: %i[create destroy]
   end
 
-  post '/archive_contest_description/:container_id/:id', to: 'contest_descriptions#archive', as: :archive_contest_description
-  post '/unarchive_contest_description/:container_id/:id', to: 'contest_descriptions#unarchive', as: :unarchive_contest_description
-  post '/archive_contest_instance/:container_id/:contest_description_id/:id', to: 'contest_instances#archive', as: :archive_contest_instance
-  post '/unarchive_contest_instance/:container_id/:contest_description_id/:id', to: 'contest_instances#unarchive', as: :unarchive_contest_instance
+  # post '/archive_contest_description/:container_id/:id', to: 'contest_descriptions#archive', as: :archive_contest_description
+  # post '/unarchive_contest_description/:container_id/:id', to: 'contest_descriptions#unarchive', as: :unarchive_contest_description
+  # post '/archive_contest_instance/:container_id/:contest_description_id/:id', to: 'contest_instances#archive', as: :archive_contest_instance
+  # post '/unarchive_contest_instance/:container_id/:contest_description_id/:id', to: 'contest_instances#unarchive', as: :unarchive_contest_instance
 
   resources :visibilities
   resources :departments

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,20 +13,17 @@ Rails.application.routes.draw do
   resources :containers do
     resources :contest_descriptions do
       collection do
-        post 'archive_contest_description', to: 'contest_descriptions#archive'
-        post 'unarchive_contest_description', to: 'contest_descriptions#unarchive'
-        post 'archive_contest_instance', to: 'contest_instances#archive'
-        post 'unarchive_contest_instance', to: 'contest_instances#unarchive'
+        post 'archive_contest_description/:id', to: 'contest_descriptions#archive', as: :archive_contest_description
+        post 'unarchive_contest_description/:id', to: 'contest_descriptions#unarchive', as: :unarchive_contest_description
       end
       resources :contest_instances, path: 'instances'
+      collection do
+        post 'archive_contest_instance/:contest_description_id/:id', to: 'contest_instances#archive', as: :archive_contest_instance
+        post 'unarchive_contest_instance/:contest_description_id/:id', to: 'contest_instances#unarchive', as: :unarchive_contest_instance
+      end
     end
     resources :assignments, only: %i[create destroy]
   end
-
-  # post '/archive_contest_description/:container_id/:id', to: 'contest_descriptions#archive', as: :archive_contest_description
-  # post '/unarchive_contest_description/:container_id/:id', to: 'contest_descriptions#unarchive', as: :unarchive_contest_description
-  # post '/archive_contest_instance/:container_id/:contest_description_id/:id', to: 'contest_instances#archive', as: :archive_contest_instance
-  # post '/unarchive_contest_instance/:container_id/:contest_description_id/:id', to: 'contest_instances#unarchive', as: :unarchive_contest_instance
 
   resources :visibilities
   resources :departments

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,10 @@ Rails.application.routes.draw do
     resources :assignments, only: %i[create destroy]
   end
 
-  post '/containers/:container_id/contest_description/:contest_description_id/archive/:id', to: 'contest_instances#archive', as: :archive_contest_instance
-  post '/containers/:container_id/contest_description/:contest_description_id/unarchive/:id', to: 'contest_instances#unarchive', as: :unarchive_contest_instance
+  post '/archive_contest_description/:container_id/:id', to: 'contest_descriptions#archive', as: :archive_contest_description
+  post '/unarchive_contest_description/:container_id/:id', to: 'contest_descriptions#unarchive', as: :unarchive_contest_description
+  post '/archive_contest_instance/:container_id/:contest_description_id/:id', to: 'contest_instances#archive', as: :archive_contest_instance
+  post '/unarchive_contest_instance/:container_id/:contest_description_id/:id', to: 'contest_instances#unarchive', as: :unarchive_contest_instance
 
   resources :visibilities
   resources :departments

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
     resources :assignments, only: %i[create destroy]
   end
 
+  post '/containers/:container_id/contest_description/:contest_description_id/archive/:id', to: 'contest_instances#archive', as: :archive_contest_instance
+  post '/containers/:container_id/contest_description/:contest_description_id/unarchive/:id', to: 'contest_instances#unarchive', as: :unarchive_contest_instance
+
   resources :visibilities
   resources :departments
   resources :roles


### PR DESCRIPTION
the pull request creates Archive/Unarchive functionality for contest descriptions and contest instances.

- Archive Inactive contest instances
  - The Archive button is displayed only for inactive contest instances (on the contest instance Show page)

- Archive a contest description if it doesn't have active instances
  - The Archive button is displayed only if the description doesn't have active instances (on the containers index page)

The Unachived button is displayed for archived contest descriptions and contest instances.