### PR TITLE
Potential fix for code scanning alert no. 1: Stored cross-site scripting

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
       safe_join([ content_html, edit_link ], ' ').html_safe
     else
       # If the user doesn't have the role, just render the content
-      content_html.html_safe
+      html_escape(content_html)
     end
   end
 


### PR DESCRIPTION
Potential fix for [https://github.com/lsa-mis/lsa_evaluate/security/code-scanning/1](https://github.com/lsa-mis/lsa_evaluate/security/code-scanning/1)

To fix the problem, we need to ensure that the content from `content_record.content` is properly escaped before being rendered as HTML. This can be achieved by using the `html_escape` method provided by Rails, which will escape any potentially dangerous characters in the content. We should replace the direct use of `content_html.html_safe` with `html_escape(content_html)` to ensure the content is safe to render.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
