### PR TITLE
Reports_take_2

### DIFF
--- a/app/controllers/containers_controller.rb
+++ b/app/controllers/containers_controller.rb
@@ -110,7 +110,7 @@ class ContainersController < ApplicationController
   end
 
   def container_params
-    params.require(:container).permit(:name, :description, :notes, :department_id, :visibility_id,
+    params.require(:container).permit(:name, :description, :notes, :contact_email, :department_id, :visibility_id,
                                       assignments_attributes: %i[id user_id role_id _destroy])
   end
 end

--- a/app/controllers/contest_instances_controller.rb
+++ b/app/controllers/contest_instances_controller.rb
@@ -104,7 +104,7 @@ class ContestInstancesController < ApplicationController
 
     # Send an email for each entry
     entries.each do |entry|
-      if Rails.env.development?
+      if Rails.env.local?
         ResultsMailer.entry_evaluation_notification(entry, judging_round).deliver_now
       else
         ResultsMailer.entry_evaluation_notification(entry, judging_round).deliver_later

--- a/app/controllers/contest_instances_controller.rb
+++ b/app/controllers/contest_instances_controller.rb
@@ -80,7 +80,7 @@ class ContestInstancesController < ApplicationController
 
   # POST /containers/:container_id/contest_descriptions/:contest_description_id/contest_instances/:id/send_round_results
   def send_round_results
-    authorize @contest_instance, :manage?
+    authorize @contest_instance, :send_round_results?
 
     round_id = params[:round_id]
     judging_round = @contest_instance.judging_rounds.find_by(id: round_id)

--- a/app/mailers/results_mailer.rb
+++ b/app/mailers/results_mailer.rb
@@ -24,7 +24,15 @@ class ResultsMailer < ApplicationMailer
     @selected_for_next_round = @rankings.any?(&:selected_for_next_round?)
 
     # Only include external comments that are meant to be shared with applicants
-    @external_comments = @rankings.map(&:external_comments).compact.reject(&:empty?)
+    # and include the judge information with each comment
+    @external_comments_with_judges = @rankings.map do |ranking|
+      if ranking.external_comments.present? && !ranking.external_comments.empty?
+        {
+          comment: ranking.external_comments,
+          judge: ranking.user.display_name_or_first_name_last_name
+        }
+      end
+    end.compact
 
     subject = "Evaluation Results for \"#{@entry.title}\" - #{@contest_description.name}"
 

--- a/app/mailers/results_mailer.rb
+++ b/app/mailers/results_mailer.rb
@@ -1,0 +1,36 @@
+class ResultsMailer < ApplicationMailer
+  def entry_evaluation_notification(entry, round)
+    @entry = entry
+    @round = round
+    @profile = entry.profile
+    @user = @profile.user
+    @contest_instance = entry.contest_instance
+    @contest_description = @contest_instance.contest_description
+    @container = @contest_description.container
+
+    # Get the contact email from the container, with fallbacks if not present
+    @contact_email = @container.contact_email.presence ||
+                    Rails.application.credentials.dig(:mailer, :default_contact_email) ||
+                    Rails.application.credentials.dig(:devise, :mailer_sender) ||
+                    'contests@example.com'
+
+    # Get all rankings for this entry in this round
+    @rankings = EntryRanking.where(entry: @entry, judging_round: @round)
+
+    # Calculate the average rank
+    @avg_rank = @round.average_rank_for_entry(@entry)
+
+    # Check if the entry was selected for the next round
+    @selected_for_next_round = @rankings.any?(&:selected_for_next_round?)
+
+    # Only include external comments that are meant to be shared with applicants
+    @external_comments = @rankings.map(&:external_comments).compact.reject(&:empty?)
+
+    subject = "Evaluation Results for \"#{@entry.title}\" - #{@contest_description.name}"
+
+    mail(
+      to: @user.email,
+      subject: subject
+    )
+  end
+end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -5,6 +5,7 @@
 # Table name: containers
 #
 #  id            :bigint           not null, primary key
+#  contact_email :string(255)
 #  name          :string(255)
 #  notes         :text(65535)
 #  created_at    :datetime         not null
@@ -40,6 +41,8 @@ class Container < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :department_id, presence: { message: 'You must select a department' }
   validates :visibility_id, presence: { message: 'You must select a visibility option' }
+  validates :contact_email, presence: { message: 'You must enter a contact email' }
+  validates :contact_email, format: { with: URI::MailTo::EMAIL_REGEXP, message: 'You must enter a valid email address' }
 
   scope :visible, -> { joins(:visibility).where(visibilities: { kind: 'Public' }) } # Only show containers with 'Public' visibility
 

--- a/app/models/judging_round.rb
+++ b/app/models/judging_round.rb
@@ -5,6 +5,7 @@
 #  id                         :bigint           not null, primary key
 #  active                     :boolean          default(FALSE), not null
 #  completed                  :boolean          default(FALSE), not null
+#  emails_sent_count          :integer          default(0), not null
 #  end_date                   :datetime
 #  min_external_comment_words :integer          default(0), not null
 #  min_internal_comment_words :integer          default(0), not null
@@ -47,6 +48,11 @@ class JudgingRound < ApplicationRecord
   scope :active, -> { where(active: true) }
 
   before_create :set_active_by_default
+
+  # Alias for completed? to match what's used in views
+  def complete?
+    completed?
+  end
 
   def activate!
     return false unless valid?

--- a/app/models/judging_round.rb
+++ b/app/models/judging_round.rb
@@ -7,6 +7,8 @@
 #  completed                  :boolean          default(FALSE), not null
 #  emails_sent_count          :integer          default(0), not null
 #  end_date                   :datetime
+#  include_advancement_status :boolean          default(FALSE)
+#  include_average_ranking    :boolean          default(FALSE)
 #  min_external_comment_words :integer          default(0), not null
 #  min_internal_comment_words :integer          default(0), not null
 #  require_external_comments  :boolean          default(FALSE), not null

--- a/app/policies/contest_instance_policy.rb
+++ b/app/policies/contest_instance_policy.rb
@@ -58,7 +58,11 @@ class ContestInstancePolicy < ApplicationPolicy
     user&.has_container_role?(record.contest_description.container) || axis_mundi?
   end
 
-    def deactivate?
+  def deactivate?
+    user&.has_container_role?(record.contest_description.container) || axis_mundi?
+  end
+
+  def send_round_results?
     user&.has_container_role?(record.contest_description.container) || axis_mundi?
   end
 end

--- a/app/views/containers/_form.html.erb
+++ b/app/views/containers/_form.html.erb
@@ -6,16 +6,18 @@
     <div class="form-inputs">
       <%= f.input :name, required: true %> <!-- This field should be required -->
       <%= f.input :description, as: :rich_text_area %>
-      
-      <%= f.input :department_id, 
-                  collection: Department.all, 
-                  label_method: :name, 
-                  value_method: :id, 
+      <%= f.input :contact_email,
+                  hint: "This email will be displayed in notifications to applicants as the contact for questions about contests in this collection." %>
+
+      <%= f.input :department_id,
+                  collection: Department.all,
+                  label_method: :name,
+                  value_method: :id,
                   required: true %> <!-- Required department -->
-      
-      <%= f.input :visibility_id, 
-                  collection: Visibility.all, 
-                  label_method: :kind, 
+
+      <%= f.input :visibility_id,
+                  collection: Visibility.all,
+                  label_method: :kind,
                   value_method: :id,
                   hint: safe_join([
                     content_tag(:strong, "Public"), " visibility means that this collection of contests will be visible in the applicant's dashboard. ",

--- a/app/views/contest_instances/_judging_results.html.erb
+++ b/app/views/contest_instances/_judging_results.html.erb
@@ -9,19 +9,14 @@
                data-bs-placement="top"
                data-bs-html="true"
                title="Email results to applicants for round <%= round.round_number %><br><small>Contact: <%= h(@container.contact_email.presence || 'Not set') %></small>">
-            <%= button_to send_round_results_container_contest_description_contest_instance_path(
+            <%= link_to email_preferences_container_contest_description_contest_instance_path(
                 @container,
                 @contest_description,
                 @contest_instance,
                 round_id: round.id
               ),
-              method: :post,
               class: "btn btn-sm btn-info me-3",
-              disabled: !round.complete?,
-              data: {
-                controller: "confirm",
-                confirm_message_value: "Are you sure you want to send evaluation results to all applicants for round #{round.round_number}?"
-              } do %>
+              disabled: !round.complete? do %>
               <i class="bi bi-envelope text-white"></i>
               Email round <%= round.round_number %> results
             <% end %>

--- a/app/views/contest_instances/_judging_results.html.erb
+++ b/app/views/contest_instances/_judging_results.html.erb
@@ -1,106 +1,138 @@
 <div class="mt-4">
+  <% if @contest_instance.judging_rounds.any? %>
+    <% @contest_instance.judging_rounds.order(:round_number).each do |round| %>
+      <div class="p-4 mb-4 card border-primary">
+        <h2>Round <%= round.round_number %></h2>
+        <div class="d-flex align-items-center mb-3">
+          <div class="d-inline-block"
+               data-bs-toggle="tooltip"
+               data-bs-placement="top"
+               data-bs-html="true"
+               title="Email results to applicants for round <%= round.round_number %><br><small>Contact: <%= h(@container.contact_email.presence || 'Not set') %></small>">
+            <%= button_to send_round_results_container_contest_description_contest_instance_path(
+                @container,
+                @contest_description,
+                @contest_instance,
+                round_id: round.id
+              ),
+              method: :post,
+              class: "btn btn-sm btn-info me-3",
+              disabled: !round.complete?,
+              data: {
+                confirm: "Are you sure you want to send evaluation results to all applicants for round #{round.round_number}?"
+              } do %>
+              <i class="bi bi-envelope text-white"></i>
+              Email round <%= round.round_number %> results
+            <% end %>
+          </div>
 
-    <% if @contest_instance.judging_rounds.any? %>
-      <% @contest_instance.judging_rounds.order(:round_number).each do |round| %>
-        <div class="mb-4">
-          <h2>Round <%= round.round_number %></h2>
-          <div class="table-responsive">
-            <table class="table">
-              <thead>
+          <% if round.emails_sent_count > 0 %>
+            <span class="badge bg-secondary"
+                  data-bs-toggle="tooltip"
+                  data-bs-placement="top"
+                  title="Number of times emails have been sent for this round">
+              <i class="bi bi-envelope-check me-1"></i>
+              Emails sent: <%= round.emails_sent_count %> time<%= 's' if round.emails_sent_count > 1 %>
+            </span>
+          <% end %>
+        </div>
+        <div class="table-responsive">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Entry ID</th>
+                <th>Title</th>
+                <th>Average Rank</th>
+                <th>Individual Rankings</th>
+                <th>Comments</th>
+                <th>Selected for Next Round</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% entries_with_avg_rank = round.entries.distinct.map do |entry|
+                    avg_rank = entry.entry_rankings.where(judging_round: round).average(:rank)
+                    [entry, avg_rank || Float::INFINITY]
+                  end.sort_by { |_, avg_rank| avg_rank } %>
+
+              <% entries_with_avg_rank.each do |entry, _| %>
                 <tr>
-                  <th>Entry ID</th>
-                  <th>Title</th>
-                  <th>Average Rank</th>
-                  <th>Individual Rankings</th>
-                  <th>Comments</th>
-                  <th>Selected for Next Round</th>
-                </tr>
-              </thead>
-              <tbody>
-                <% entries_with_avg_rank = round.entries.distinct.map do |entry|
-                     avg_rank = entry.entry_rankings.where(judging_round: round).average(:rank)
-                     [entry, avg_rank || Float::INFINITY]
-                   end.sort_by { |_, avg_rank| avg_rank } %>
-
-                <% entries_with_avg_rank.each do |entry, _| %>
-                  <tr>
-                    <td><%= entry.id %></td>
-                    <td><%= entry.title %></td>
-                    <td>
-                      <%= entry.entry_rankings.where(judging_round: round).average(:rank)&.round(2) || 'No rankings' %>
-                    </td>
-                    <td>
-                      <div class="rankings-container">
-                        <% rankings = entry.entry_rankings.where(judging_round: round) %>
-                        <% if rankings.any? %>
-                          <% rankings.each do |ranking| %>
-                            <div class="mb-2 d-flex align-items-center" style="font-size: 0.9rem;">
-                              <div class="rankings-email">
-                                <%= content_tag(:span,
-                                  display_email(ranking.user.email),
-                                  data: {
-                                    'bs-toggle': 'tooltip',
-                                    'bs-html': 'true',
-                                    'bs-title': "#{h(ranking.user.display_name_or_first_name_last_name)}<br>#{h(display_email(ranking.user.email))}"
-                                  }
-                                ) %>
-                              </div>
-                              <span class="badge bg-secondary ranking-badge"><%= ranking.rank || 'Not ranked' %></span>
-                            </div>
-                          <% end %>
-                        <% else %>
-                          <div class="text-muted">No rankings yet</div>
-                        <% end %>
-                      </div>
-                    </td>
-                    <td>
-                      <div class="comments-container scrollable-container">
-                        <% rankings = entry.entry_rankings.where(judging_round: round) %>
-                        <% has_comments = false %>
+                  <td><%= entry.id %></td>
+                  <td><%= entry.title %></td>
+                  <td>
+                    <%= entry.entry_rankings.where(judging_round: round).average(:rank)&.round(2) || 'No rankings' %>
+                  </td>
+                  <td>
+                    <div class="rankings-container">
+                      <% rankings = entry.entry_rankings.where(judging_round: round) %>
+                      <% if rankings.any? %>
                         <% rankings.each do |ranking| %>
-                          <% if ranking.external_comments.present? || ranking.internal_comments.present? %>
-                            <% has_comments = true %>
-                            <div class="mb-2 border-bottom pb-2">
-                              <strong><%= content_tag(:span,
+                          <div class="mb-2 d-flex align-items-center" style="font-size: 0.9rem;">
+                            <div class="rankings-email">
+                              <%= content_tag(:span,
                                 display_email(ranking.user.email),
                                 data: {
                                   'bs-toggle': 'tooltip',
                                   'bs-html': 'true',
                                   'bs-title': "#{h(ranking.user.display_name_or_first_name_last_name)}<br>#{h(display_email(ranking.user.email))}"
                                 }
-                              ) %></strong>
-                              <% if ranking.external_comments.present? %>
-                                <div class="text-muted small mt-1">
-                                  <strong class="text-primary">External:</strong>
-                                  <%= ranking.external_comments %>
-                                </div>
-                              <% end %>
-                              <% if ranking.internal_comments.present? %>
-                                <div class="text-muted small mt-1">
-                                  <strong class="text-secondary">Internal:</strong>
-                                  <%= ranking.internal_comments %>
-                                </div>
-                              <% end %>
+                              ) %>
                             </div>
-                          <% end %>
+                            <span class="badge bg-secondary ranking-badge"><%= ranking.rank || 'Not ranked' %></span>
+                          </div>
                         <% end %>
-                        <% unless has_comments %>
-                          <div class="text-muted">No comments yet</div>
+                      <% else %>
+                        <div class="text-muted">No rankings yet</div>
+                      <% end %>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="comments-container scrollable-container">
+                      <% rankings = entry.entry_rankings.where(judging_round: round) %>
+                      <% has_comments = false %>
+                      <% rankings.each do |ranking| %>
+                        <% if ranking.external_comments.present? || ranking.internal_comments.present? %>
+                          <% has_comments = true %>
+                          <div class="mb-2 border-bottom pb-2">
+                            <strong><%= content_tag(:span,
+                              display_email(ranking.user.email),
+                              data: {
+                                'bs-toggle': 'tooltip',
+                                'bs-html': 'true',
+                                'bs-title': "#{h(ranking.user.display_name_or_first_name_last_name)}<br>#{h(display_email(ranking.user.email))}"
+                              }
+                            ) %></strong>
+                            <% if ranking.external_comments.present? %>
+                              <div class="text-muted small mt-1">
+                                <strong class="text-primary">External:</strong>
+                                <%= ranking.external_comments %>
+                              </div>
+                            <% end %>
+                            <% if ranking.internal_comments.present? %>
+                              <div class="text-muted small mt-1">
+                                <strong class="text-secondary">Internal:</strong>
+                                <%= ranking.internal_comments %>
+                              </div>
+                            <% end %>
+                          </div>
                         <% end %>
-                        <div style="height: 180px;"></div>
-                      </div>
-                    </td>
-                    <td class="text-center">
-                      <%= boolean_to_yes_no(entry.entry_rankings.where(judging_round: round, selected_for_next_round: true).exists?) %>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
+                      <% end %>
+                      <% unless has_comments %>
+                        <div class="text-muted">No comments yet</div>
+                      <% end %>
+                      <div style="height: 180px;"></div>
+                    </div>
+                  </td>
+                  <td class="text-center">
+                    <%= boolean_to_yes_no(entry.entry_rankings.where(judging_round: round, selected_for_next_round: true).exists?) %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
         </div>
-      <% end %>
-    <% else %>
-      <p class="text-muted">No judging rounds have been created yet.</p>
+      </div>
     <% end %>
+  <% else %>
+    <p class="text-muted">No judging rounds have been created yet.</p>
+  <% end %>
 </div>

--- a/app/views/contest_instances/_judging_results.html.erb
+++ b/app/views/contest_instances/_judging_results.html.erb
@@ -19,7 +19,8 @@
               class: "btn btn-sm btn-info me-3",
               disabled: !round.complete?,
               data: {
-                confirm: "Are you sure you want to send evaluation results to all applicants for round #{round.round_number}?"
+                controller: "confirm",
+                confirm_message_value: "Are you sure you want to send evaluation results to all applicants for round #{round.round_number}?"
               } do %>
               <i class="bi bi-envelope text-white"></i>
               Email round <%= round.round_number %> results

--- a/app/views/contest_instances/email_preferences.html.erb
+++ b/app/views/contest_instances/email_preferences.html.erb
@@ -1,0 +1,49 @@
+<h1>Email Results Preferences</h1>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h2>Round <%= @judging_round.round_number %> Email Content Options</h2>
+  </div>
+  <div class="card-body">
+    <p class="mb-4">
+      Select which information to include in the evaluation result emails for this round:
+    </p>
+
+    <%= form_with url: send_round_results_container_contest_description_contest_instance_path(
+          @container,
+          @contest_description,
+          @contest_instance,
+          round_id: @judging_round.id
+        ),
+        method: :post,
+        class: "email-preferences-form",
+        data: {
+          controller: "confirm",
+          confirm_message_value: "Are you sure you want to send evaluation results to all applicants for round #{@judging_round.round_number}?"
+        } do |f| %>
+
+      <div class="form-check mb-3">
+        <%= f.check_box :include_average_ranking,
+              id: "include_average_ranking",
+              class: "form-check-input",
+              checked: @judging_round.include_average_ranking %>
+        <%= f.label :include_average_ranking, "Include average ranking information", class: "form-check-label" %>
+        <div class="form-text">When checked, emails will include the average ranking each entry received from judges.</div>
+      </div>
+
+      <div class="form-check mb-4">
+        <%= f.check_box :include_advancement_status,
+              id: "include_advancement_status",
+              class: "form-check-input",
+              checked: @judging_round.include_advancement_status %>
+        <%= f.label :include_advancement_status, "Include advancement status information", class: "form-check-label" %>
+        <div class="form-text">When checked, emails will include whether the entry was selected to advance to the next round or was selected as a finalist.</div>
+      </div>
+
+      <div class="d-flex mt-4">
+        <%= f.submit "Send Emails", class: "btn btn-primary me-2" %>
+        <%= link_to "Cancel", container_contest_description_contest_instance_path(@container, @contest_description, @contest_instance), class: "btn btn-secondary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/mailers/results_mailer/entry_evaluation_notification.html.erb
+++ b/app/views/mailers/results_mailer/entry_evaluation_notification.html.erb
@@ -96,28 +96,30 @@
 
     <h2>Evaluation Results - Round <%= @round.round_number %></h2>
 
-    <% if @avg_rank.present? %>
+    <% if @avg_rank.present? && @round.include_average_ranking %>
       <p>Your submission received an average ranking of <span class="result-highlight"><%= @avg_rank %></span> from our judging panel.</p>
     <% end %>
 
-    <% if @selected_for_next_round && @contest_instance.judging_rounds.exists?(round_number: @round.round_number + 1) %>
-      <div class="advance-notice">
-        <p><strong>Congratulations!</strong> Your entry has been selected to advance to Round <%= @round.round_number + 1 %>.</p>
-      </div>
-    <% elsif @round.round_number == @contest_instance.judging_rounds.maximum(:round_number) %>
-      <% if @selected_for_next_round %>
+    <% if @round.include_advancement_status %>
+      <% if @selected_for_next_round && @contest_instance.judging_rounds.exists?(round_number: @round.round_number + 1) %>
         <div class="advance-notice">
-          <p><strong>Congratulations!</strong> Your entry has been selected as a finalist.</p>
+          <p><strong>Congratulations!</strong> Your entry has been selected to advance to Round <%= @round.round_number + 1 %>.</p>
         </div>
-      <% else %>
+      <% elsif @round.round_number == @contest_instance.judging_rounds.maximum(:round_number) %>
+        <% if @selected_for_next_round %>
+          <div class="advance-notice">
+            <p><strong>Congratulations!</strong> Your entry has been selected as a finalist.</p>
+          </div>
+        <% else %>
+          <div class="not-advance-notice">
+            <p>We regret to inform you that your entry was not selected as a finalist.</p>
+          </div>
+        <% end %>
+      <% elsif !@selected_for_next_round %>
         <div class="not-advance-notice">
-          <p>We regret to inform you that your entry was not selected as a finalist.</p>
+          <p>We regret to inform you that your entry was not selected to advance to the next round of judging.</p>
         </div>
       <% end %>
-    <% elsif !@selected_for_next_round %>
-      <div class="not-advance-notice">
-        <p>We regret to inform you that your entry was not selected to advance to the next round of judging.</p>
-      </div>
     <% end %>
 
     <% if @external_comments_with_judges.any? %>

--- a/app/views/mailers/results_mailer/entry_evaluation_notification.html.erb
+++ b/app/views/mailers/results_mailer/entry_evaluation_notification.html.erb
@@ -49,6 +49,11 @@
       background-color: #f9f9f9;
       border-left: 3px solid #1a5a96;
     }
+    .judge-name {
+      color: #1a5a96;
+      margin-bottom: 5px;
+      font-size: 0.9em;
+    }
     .advance-notice {
       background-color: #d4edda;
       color: #155724;
@@ -115,13 +120,14 @@
       </div>
     <% end %>
 
-    <% if @external_comments.any? %>
+    <% if @external_comments_with_judges.any? %>
       <h3>Feedback from Judges</h3>
       <p>Our judges have provided the following feedback on your submission:</p>
 
-      <% @external_comments.each do |comment| %>
+      <% @external_comments_with_judges.each do |comment_data| %>
         <div class="comment">
-          <%= simple_format(comment) %>
+          <p class="judge-name"><strong>From Judge: <%= comment_data[:judge] %></strong></p>
+          <%= simple_format(comment_data[:comment]) %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/mailers/results_mailer/entry_evaluation_notification.html.erb
+++ b/app/views/mailers/results_mailer/entry_evaluation_notification.html.erb
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      color: #333;
+      line-height: 1.5;
+    }
+    .container {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    .header {
+      padding-bottom: 20px;
+      border-bottom: 1px solid #eee;
+      margin-bottom: 20px;
+    }
+    .logo {
+      max-width: 150px;
+    }
+    h1, h2, h3 {
+      color: #1a5a96;
+      margin-top: 20px;
+    }
+    .entry-details {
+      background-color: #f5f5f5;
+      padding: 15px;
+      border-radius: 5px;
+      margin-bottom: 20px;
+    }
+    .footer {
+      margin-top: 30px;
+      padding-top: 20px;
+      border-top: 1px solid #eee;
+      font-size: 0.8em;
+      color: #666;
+    }
+    .result-highlight {
+      font-weight: bold;
+      color: #1a5a96;
+      font-size: 1.1em;
+    }
+    .comment {
+      margin-bottom: 15px;
+      padding: 10px;
+      background-color: #f9f9f9;
+      border-left: 3px solid #1a5a96;
+    }
+    .advance-notice {
+      background-color: #d4edda;
+      color: #155724;
+      padding: 10px;
+      border-radius: 5px;
+      margin-top: 20px;
+    }
+    .not-advance-notice {
+      background-color: #f8d7da;
+      color: #721c24;
+      padding: 10px;
+      border-radius: 5px;
+      margin-top: 20px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <!-- Optional logo -->
+      <!-- <img src="[LOGO_URL]" alt="University Logo" class="logo"> -->
+      <h1><%= @contest_description.name %></h1>
+    </div>
+
+    <p>Dear <%= @user.display_name_or_first_name_last_name %>,</p>
+
+    <p>Thank you for your submission to the <%= @contest_description.name %>. We appreciate your participation and the effort you put into your work.</p>
+
+    <div class="entry-details">
+      <h2>Your Entry Details</h2>
+      <p><strong>Title:</strong> <%= @entry.title %></p>
+      <p><strong>Submitted:</strong> <%= @entry.created_at.strftime("%B %d, %Y") %></p>
+      <% if @entry.category.present? %>
+        <p><strong>Category:</strong> <%= @entry.category.kind %></p>
+      <% end %>
+      <% if @entry.pen_name.present? %>
+        <p><strong>Pen Name:</strong> <%= @entry.pen_name %></p>
+      <% end %>
+    </div>
+
+    <h2>Evaluation Results - Round <%= @round.round_number %></h2>
+
+    <% if @avg_rank.present? %>
+      <p>Your submission received an average ranking of <span class="result-highlight"><%= @avg_rank %></span> from our judging panel.</p>
+    <% end %>
+
+    <% if @selected_for_next_round && @contest_instance.judging_rounds.exists?(round_number: @round.round_number + 1) %>
+      <div class="advance-notice">
+        <p><strong>Congratulations!</strong> Your entry has been selected to advance to Round <%= @round.round_number + 1 %>.</p>
+      </div>
+    <% elsif @round.round_number == @contest_instance.judging_rounds.maximum(:round_number) %>
+      <% if @selected_for_next_round %>
+        <div class="advance-notice">
+          <p><strong>Congratulations!</strong> Your entry has been selected as a finalist.</p>
+        </div>
+      <% else %>
+        <div class="not-advance-notice">
+          <p>We regret to inform you that your entry was not selected as a finalist.</p>
+        </div>
+      <% end %>
+    <% elsif !@selected_for_next_round %>
+      <div class="not-advance-notice">
+        <p>We regret to inform you that your entry was not selected to advance to the next round of judging.</p>
+      </div>
+    <% end %>
+
+    <% if @external_comments.any? %>
+      <h3>Feedback from Judges</h3>
+      <p>Our judges have provided the following feedback on your submission:</p>
+
+      <% @external_comments.each do |comment| %>
+        <div class="comment">
+          <%= simple_format(comment) %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <p>We value your creativity and hope you found this competition to be a rewarding experience. Your participation contributes to the vibrant artistic and academic community at our university.</p>
+
+    <% if @contact_email.present? %>
+      <p>If you have any questions about the judging process or results, please contact <%= @contact_email %>.</p>
+    <% end %>
+
+    <div class="footer">
+      <p>This is an automated email. Please do not reply to this message.</p>
+      <p>&copy; <%= Date.today.year %> <%= @container.name %> | All Rights Reserved</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/app/views/mailers/results_mailer/entry_evaluation_notification.text.erb
+++ b/app/views/mailers/results_mailer/entry_evaluation_notification.text.erb
@@ -29,13 +29,14 @@ We regret to inform you that your entry was not selected as a finalist.
 We regret to inform you that your entry was not selected to advance to the next round of judging.
 <% end %>
 
-<% if @external_comments.any? %>
+<% if @external_comments_with_judges.any? %>
 FEEDBACK FROM JUDGES
 =================
 Our judges have provided the following feedback on your submission:
 
-<% @external_comments.each do |comment| %>
-* <%= comment.gsub(/\n/, "\n  ") %>
+<% @external_comments_with_judges.each do |comment_data| %>
+* From Judge: <%= comment_data[:judge] %>
+  <%= comment_data[:comment].gsub(/\n/, "\n  ") %>
 
 <% end %>
 <% end %>

--- a/app/views/mailers/results_mailer/entry_evaluation_notification.text.erb
+++ b/app/views/mailers/results_mailer/entry_evaluation_notification.text.erb
@@ -13,10 +13,11 @@ Submitted: <%= @entry.created_at.strftime("%B %d, %Y") %>
 
 EVALUATION RESULTS - ROUND <%= @round.round_number %>
 =================
-<% if @avg_rank.present? %>
+<% if @avg_rank.present? && @round.include_average_ranking %>
 Your submission received an average ranking of <%= @avg_rank %> from our judging panel.
 <% end %>
 
+<% if @round.include_advancement_status %>
 <% if @selected_for_next_round && @contest_instance.judging_rounds.exists?(round_number: @round.round_number + 1) %>
 CONGRATULATIONS! Your entry has been selected to advance to Round <%= @round.round_number + 1 %>.
 <% elsif @round.round_number == @contest_instance.judging_rounds.maximum(:round_number) %>
@@ -27,6 +28,7 @@ We regret to inform you that your entry was not selected as a finalist.
 <% end %>
 <% elsif !@selected_for_next_round %>
 We regret to inform you that your entry was not selected to advance to the next round of judging.
+<% end %>
 <% end %>
 
 <% if @external_comments_with_judges.any? %>

--- a/app/views/mailers/results_mailer/entry_evaluation_notification.text.erb
+++ b/app/views/mailers/results_mailer/entry_evaluation_notification.text.erb
@@ -1,0 +1,51 @@
+<%= @contest_description.name %>
+
+Dear <%= @user.display_name_or_first_name_last_name %>,
+
+Thank you for your submission to the <%= @contest_description.name %>. We appreciate your participation and the effort you put into your work.
+
+YOUR ENTRY DETAILS
+=================
+Title: <%= @entry.title %>
+Submitted: <%= @entry.created_at.strftime("%B %d, %Y") %>
+<% if @entry.category.present? %>Category: <%= @entry.category.kind %><% end %>
+<% if @entry.pen_name.present? %>Pen Name: <%= @entry.pen_name %><% end %>
+
+EVALUATION RESULTS - ROUND <%= @round.round_number %>
+=================
+<% if @avg_rank.present? %>
+Your submission received an average ranking of <%= @avg_rank %> from our judging panel.
+<% end %>
+
+<% if @selected_for_next_round && @contest_instance.judging_rounds.exists?(round_number: @round.round_number + 1) %>
+CONGRATULATIONS! Your entry has been selected to advance to Round <%= @round.round_number + 1 %>.
+<% elsif @round.round_number == @contest_instance.judging_rounds.maximum(:round_number) %>
+<% if @selected_for_next_round %>
+CONGRATULATIONS! Your entry has been selected as a finalist.
+<% else %>
+We regret to inform you that your entry was not selected as a finalist.
+<% end %>
+<% elsif !@selected_for_next_round %>
+We regret to inform you that your entry was not selected to advance to the next round of judging.
+<% end %>
+
+<% if @external_comments.any? %>
+FEEDBACK FROM JUDGES
+=================
+Our judges have provided the following feedback on your submission:
+
+<% @external_comments.each do |comment| %>
+* <%= comment.gsub(/\n/, "\n  ") %>
+
+<% end %>
+<% end %>
+
+We value your creativity and hope you found this competition to be a rewarding experience. Your participation contributes to the vibrant artistic and academic community at our university.
+
+<% if @contact_email.present? %>
+If you have any questions about the judging process or results, please contact <%= @contact_email %>.
+<% end %>
+
+---
+This is an automated email. Please do not reply to this message.
+© <%= Date.today.year %> <%= @container.name %> | All Rights Reserved

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,6 +51,10 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.perform_deliveries = true
 
+  # Use the inline adapter for Active Job in development so emails sent with deliver_later
+  # will be processed immediately and show up in letter_opener_web
+  config.active_job.queue_adapter = :inline
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,6 +45,12 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Configure ActiveJob to run synchronously in test environment
+  config.active_job.queue_adapter = :inline
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,9 @@ Rails.application.routes.draw do
   resources :containers do
     resources :contest_descriptions do
       resources :contest_instances do
+        member do
+          post 'send_round_results'
+        end
         resources :judging_rounds do
           member do
             patch :activate

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
     resources :contest_descriptions do
       resources :contest_instances do
         member do
+          get 'email_preferences'
           post 'send_round_results'
         end
         resources :judging_rounds do

--- a/db/migrate/20250311192043_add_emails_sent_count_to_judging_rounds.rb
+++ b/db/migrate/20250311192043_add_emails_sent_count_to_judging_rounds.rb
@@ -1,0 +1,5 @@
+class AddEmailsSentCountToJudgingRounds < ActiveRecord::Migration[7.2]
+  def change
+    add_column :judging_rounds, :emails_sent_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20250311193603_add_contact_email_to_containers.rb
+++ b/db/migrate/20250311193603_add_contact_email_to_containers.rb
@@ -1,0 +1,5 @@
+class AddContactEmailToContainers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :containers, :contact_email, :string
+  end
+end

--- a/db/migrate/20250312173602_add_email_preferences_to_judging_rounds.rb
+++ b/db/migrate/20250312173602_add_email_preferences_to_judging_rounds.rb
@@ -1,0 +1,6 @@
+class AddEmailPreferencesToJudgingRounds < ActiveRecord::Migration[7.2]
+  def change
+    add_column :judging_rounds, :include_average_ranking, :boolean, default: false
+    add_column :judging_rounds, :include_advancement_status, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_11_193603) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_12_173602) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -271,6 +271,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_11_193603) do
     t.text "special_instructions"
     t.integer "required_entries_count", default: 0, null: false
     t.integer "emails_sent_count", default: 0, null: false
+    t.boolean "include_average_ranking", default: false
+    t.boolean "include_advancement_status", default: false
     t.index ["contest_instance_id", "round_number"], name: "index_judging_rounds_on_contest_instance_id_and_round_number", unique: true
     t.index ["contest_instance_id"], name: "index_judging_rounds_on_contest_instance_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_08_193135) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_11_193603) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -147,6 +147,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_08_193135) do
     t.bigint "visibility_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "contact_email"
     t.index ["department_id"], name: "index_containers_on_department_id"
     t.index ["visibility_id"], name: "index_containers_on_visibility_id"
   end
@@ -269,6 +270,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_08_193135) do
     t.integer "min_external_comment_words", default: 0, null: false
     t.text "special_instructions"
     t.integer "required_entries_count", default: 0, null: false
+    t.integer "emails_sent_count", default: 0, null: false
     t.index ["contest_instance_id", "round_number"], name: "index_judging_rounds_on_contest_instance_id_and_round_number", unique: true
     t.index ["contest_instance_id"], name: "index_judging_rounds_on_contest_instance_id"
   end

--- a/spec/controllers/contest_instances_controller_spec.rb
+++ b/spec/controllers/contest_instances_controller_spec.rb
@@ -3,6 +3,71 @@ require 'rails_helper'
 RSpec.describe ContestInstancesController, type: :controller do
   # Add existing specs if there are any...
 
+  describe 'GET #email_preferences' do
+    let(:department) { create(:department) }
+    let(:user) { create(:user, :axis_mundi) } # Admin user with full privileges
+    let(:container) { create(:container, department: department) }
+    let(:contest_description) { create(:contest_description, container: container) }
+    let(:contest_instance) { create(:contest_instance, contest_description: contest_description) }
+    let(:judging_round) { create(:judging_round, contest_instance: contest_instance, completed: true) }
+
+    before do
+      sign_in user
+    end
+
+    it 'renders the email_preferences template' do
+      get :email_preferences, params: {
+        container_id: container.id,
+        contest_description_id: contest_description.id,
+        id: contest_instance.id,
+        round_id: judging_round.id
+      }
+
+      expect(response).to render_template(:email_preferences)
+    end
+
+    it 'assigns the judging round' do
+      get :email_preferences, params: {
+        container_id: container.id,
+        contest_description_id: contest_description.id,
+        id: contest_instance.id,
+        round_id: judging_round.id
+      }
+
+      expect(assigns(:judging_round)).to eq(judging_round)
+    end
+
+    context 'with non-existent judging round' do
+      it 'redirects with an alert' do
+        get :email_preferences, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          id: contest_instance.id,
+          round_id: 9999 # Non-existent round
+        }
+
+        expect(response).to redirect_to(container_contest_description_contest_instance_path(container, contest_description, contest_instance))
+        expect(flash[:alert]).to eq('Judging round not found.')
+      end
+    end
+
+    context 'with incomplete judging round' do
+      let(:incomplete_round) { create(:judging_round, contest_instance: contest_instance, completed: false) }
+
+      it 'redirects with an alert' do
+        get :email_preferences, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          id: contest_instance.id,
+          round_id: incomplete_round.id
+        }
+
+        expect(response).to redirect_to(container_contest_description_contest_instance_path(container, contest_description, contest_instance))
+        expect(flash[:alert]).to eq('Cannot send results for an incomplete judging round.')
+      end
+    end
+  end
+
   describe 'POST #send_round_results' do
     let(:department) { create(:department) }
     let(:user) { create(:user, :axis_mundi) } # Admin user with full privileges
@@ -68,6 +133,42 @@ RSpec.describe ContestInstancesController, type: :controller do
         expect(response).to redirect_to(container_contest_description_contest_instance_path(container, contest_description, contest_instance))
         expect(flash[:notice]).to include("Successfully queued 2 evaluation result emails")
         expect(flash[:notice]).to include("email batch #1")
+      end
+
+      it 'updates email preferences when provided' do
+        # Initially both preferences should be true (default)
+        judging_round.update(include_average_ranking: true, include_advancement_status: true)
+
+        post :send_round_results, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          id: contest_instance.id,
+          round_id: judging_round.id,
+          include_average_ranking: "0",
+          include_advancement_status: "0"
+        }
+
+        # After the request, both should be false
+        judging_round.reload
+        expect(judging_round.include_average_ranking).to be false
+        expect(judging_round.include_advancement_status).to be false
+      end
+
+      it 'preserves email preferences when not provided' do
+        # Set initial values
+        judging_round.update(include_average_ranking: false, include_advancement_status: false)
+
+        post :send_round_results, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          id: contest_instance.id,
+          round_id: judging_round.id
+        }
+
+        # Values should remain unchanged
+        judging_round.reload
+        expect(judging_round.include_average_ranking).to be false
+        expect(judging_round.include_advancement_status).to be false
       end
     end
 

--- a/spec/controllers/contest_instances_controller_spec.rb
+++ b/spec/controllers/contest_instances_controller_spec.rb
@@ -1,0 +1,126 @@
+require 'rails_helper'
+
+RSpec.describe ContestInstancesController, type: :controller do
+  # Add existing specs if there are any...
+
+  describe 'POST #send_round_results' do
+    let(:department) { create(:department) }
+    let(:user) { create(:user, :axis_mundi) } # Admin user with full privileges
+    let(:container) { create(:container, department: department) }
+    let(:contest_description) { create(:contest_description, container: container) }
+    let(:contest_instance) { create(:contest_instance, contest_description: contest_description) }
+
+    before do
+      sign_in user
+    end
+
+    context 'with valid judging round' do
+      let(:judging_round) { create(:judging_round, contest_instance: contest_instance, completed: true) }
+      let(:profile1) { create(:profile) }
+      let(:profile2) { create(:profile) }
+      let(:entry1) { create(:entry, contest_instance: contest_instance, profile: profile1) }
+      let(:entry2) { create(:entry, contest_instance: contest_instance, profile: profile2) }
+      let!(:entry_ranking1) { create(:entry_ranking, :with_assigned_judge, entry: entry1, judging_round: judging_round) }
+      let!(:entry_ranking2) { create(:entry_ranking, :with_assigned_judge, entry: entry2, judging_round: judging_round) }
+
+      before do
+        # Add entries to the judging round
+        allow(judging_round).to receive(:entries).and_return([ entry1, entry2 ])
+        allow(judging_round.entries).to receive(:uniq).and_return([ entry1, entry2 ])
+
+        # Configure ActiveJob to use inline adapter for testing
+        ActiveJob::Base.queue_adapter = :inline
+      end
+
+      it 'sends emails for each entry' do
+        expect(ResultsMailer).to receive(:entry_evaluation_notification).with(entry1, judging_round).and_call_original
+        expect(ResultsMailer).to receive(:entry_evaluation_notification).with(entry2, judging_round).and_call_original
+
+        expect {
+          post :send_round_results, params: {
+            container_id: container.id,
+            contest_description_id: contest_description.id,
+            id: contest_instance.id,
+            round_id: judging_round.id
+          }
+        }.to change { ActionMailer::Base.deliveries.count }.by(2)
+      end
+
+      it 'increments the emails_sent_count for the judging round' do
+        expect {
+          post :send_round_results, params: {
+            container_id: container.id,
+            contest_description_id: contest_description.id,
+            id: contest_instance.id,
+            round_id: judging_round.id
+          }
+        }.to change { judging_round.reload.emails_sent_count }.by(1)
+      end
+
+      it 'redirects with a success notice' do
+        post :send_round_results, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          id: contest_instance.id,
+          round_id: judging_round.id
+        }
+
+        expect(response).to redirect_to(container_contest_description_contest_instance_path(container, contest_description, contest_instance))
+        expect(flash[:notice]).to include("Successfully queued 2 evaluation result emails")
+        expect(flash[:notice]).to include("email batch #1")
+      end
+    end
+
+    context 'with non-existent judging round' do
+      it 'redirects with an alert' do
+        post :send_round_results, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          id: contest_instance.id,
+          round_id: 9999 # Non-existent round
+        }
+
+        expect(response).to redirect_to(container_contest_description_contest_instance_path(container, contest_description, contest_instance))
+        expect(flash[:alert]).to eq('Judging round not found.')
+      end
+    end
+
+    context 'with incomplete judging round' do
+      let(:judging_round) { create(:judging_round, contest_instance: contest_instance, completed: false) }
+
+      it 'redirects with an alert' do
+        post :send_round_results, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          id: contest_instance.id,
+          round_id: judging_round.id
+        }
+
+        expect(response).to redirect_to(container_contest_description_contest_instance_path(container, contest_description, contest_instance))
+        expect(flash[:alert]).to eq('Cannot send results for an incomplete judging round.')
+      end
+    end
+
+    context 'with unauthorized user' do
+      let(:regular_user) { create(:user) }
+      let(:judging_round) { create(:judging_round, contest_instance: contest_instance, completed: true) }
+
+      before do
+        sign_out user
+        sign_in regular_user
+      end
+
+      it 'does not allow access to the action' do
+        post :send_round_results, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          id: contest_instance.id,
+          round_id: judging_round.id
+        }
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to match(/not authorized/i)
+      end
+    end
+  end
+end

--- a/spec/factories/containers.rb
+++ b/spec/factories/containers.rb
@@ -28,5 +28,6 @@ FactoryBot.define do
     department
     visibility
     notes { "Notes for #{name}" }
+    contact_email { "contact@example.com" }
   end
 end

--- a/spec/factories/containers.rb
+++ b/spec/factories/containers.rb
@@ -3,6 +3,7 @@
 # Table name: containers
 #
 #  id            :bigint           not null, primary key
+#  contact_email :string(255)
 #  name          :string(255)
 #  notes         :text(65535)
 #  created_at    :datetime         not null

--- a/spec/factories/judging_rounds.rb
+++ b/spec/factories/judging_rounds.rb
@@ -7,6 +7,8 @@
 #  completed                  :boolean          default(FALSE), not null
 #  emails_sent_count          :integer          default(0), not null
 #  end_date                   :datetime
+#  include_advancement_status :boolean          default(FALSE)
+#  include_average_ranking    :boolean          default(FALSE)
 #  min_external_comment_words :integer          default(0), not null
 #  min_internal_comment_words :integer          default(0), not null
 #  require_external_comments  :boolean          default(FALSE), not null

--- a/spec/factories/judging_rounds.rb
+++ b/spec/factories/judging_rounds.rb
@@ -5,6 +5,7 @@
 #  id                         :bigint           not null, primary key
 #  active                     :boolean          default(FALSE), not null
 #  completed                  :boolean          default(FALSE), not null
+#  emails_sent_count          :integer          default(0), not null
 #  end_date                   :datetime
 #  min_external_comment_words :integer          default(0), not null
 #  min_internal_comment_words :integer          default(0), not null

--- a/spec/mailers/results_mailer_spec.rb
+++ b/spec/mailers/results_mailer_spec.rb
@@ -1,0 +1,126 @@
+require 'rails_helper'
+
+RSpec.describe ResultsMailer, type: :mailer do
+  describe '#entry_evaluation_notification' do
+    # Create all required test data
+    let(:user) { create(:user, email: 'applicant@example.com', first_name: 'John', last_name: 'Applicant') }
+    let(:profile) { create(:profile, user: user) }
+    let(:department) { create(:department) }
+    let(:container) { create(:container, name: 'Test Container', department: department, contact_email: 'contact@example.com') }
+    let(:contest_description) { create(:contest_description, name: 'Test Contest', container: container) }
+    let(:contest_instance) { create(:contest_instance, contest_description: contest_description, date_open: 2.months.ago, date_closed: 1.month.ago) }
+    let(:category) { create(:category, kind: 'Poetry') }
+    let(:entry) { create(:entry, title: 'Test Entry', profile: profile, contest_instance: contest_instance, category: category, pen_name: 'Writer Pen') }
+    # Create a second entry for the second ranking
+    let(:entry2) { create(:entry, title: 'Second Entry', profile: profile, contest_instance: contest_instance, category: category, pen_name: 'Writer Pen') }
+    let(:judging_round) { create(:judging_round, contest_instance: contest_instance, round_number: 1, completed: true,
+                                start_date: 3.weeks.ago, end_date: 2.weeks.ago) }
+    let(:judge) { create(:user, :with_judge_role) }
+
+    # Create the judging assignment to link the judge to the contest
+    let!(:judging_assignment) { create(:judging_assignment, user: judge, contest_instance: contest_instance) }
+    # Assign judge to the round
+    let!(:round_judge_assignment) { create(:round_judge_assignment, user: judge, judging_round: judging_round) }
+
+    # Create test rankings - using different entries
+    let!(:ranking1) { create(:entry_ranking, entry: entry, user: judge, judging_round: judging_round, rank: 1, external_comments: 'Great work!', selected_for_next_round: true) }
+    let!(:ranking2) { create(:entry_ranking, entry: entry2, user: judge, judging_round: judging_round, rank: 2, external_comments: 'Impressive submission.') }
+
+    let(:mail) { described_class.entry_evaluation_notification(entry, judging_round) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq("Evaluation Results for \"Test Entry\" - Test Contest")
+      expect(mail.to).to eq([ 'applicant@example.com' ])
+      expect(mail.from).to eq([ Rails.application.credentials.dig(:devise, :mailer_sender) || 'from@example.com' ])
+    end
+
+    it 'renders the entry details in the body' do
+      expect(mail.body.encoded).to include('Test Entry')
+      expect(mail.body.encoded).to include('Category: Poetry')
+      expect(mail.body.encoded).to include('Pen Name: Writer Pen')
+    end
+
+    it 'includes the average ranking' do
+      # We'll use only ranking1 since it's the one for our entry
+      expect(mail.body.encoded).to include('average ranking of 1')
+    end
+
+    it 'includes the external comments' do
+      expect(mail.body.encoded).to include('Great work!')
+      expect(mail.body.encoded).not_to include('Impressive submission.') # This is for entry2
+    end
+
+    it 'indicates the entry was selected for the next round' do
+      expect(mail.body.encoded).to include('Congratulations')
+      expect(mail.body.encoded).to include('has been selected')
+    end
+
+    it 'includes the contact email' do
+      expect(mail.body.encoded).to include('contact@example.com')
+    end
+
+    context 'when container has no contact email' do
+      # Use allow to bypass the validation rather than trying to create an invalid container
+      before do
+        # Mock the container's contact_email method to return nil or empty string
+        allow_any_instance_of(Container).to receive(:contact_email).and_return(nil)
+      end
+
+      it 'falls back to the default contact email from credentials' do
+        default_email = Rails.application.credentials.dig(:mailer, :default_contact_email)
+
+        if default_email
+          expect(mail.body.encoded).to include(default_email)
+        else
+          default_sender = Rails.application.credentials.dig(:devise, :mailer_sender) || 'contests@example.com'
+          expect(mail.body.encoded).to include(default_sender)
+        end
+      end
+    end
+
+    context 'when entry was not selected for next round' do
+      # Use the same approach with the judge
+      before do
+        # Update the existing ranking to be not selected for next round
+        ranking1.update_column(:selected_for_next_round, false)
+      end
+
+      it 'indicates the entry was not selected' do
+        expect(mail.body.encoded).to include('regret to inform you')
+        expect(mail.body.encoded).to include('not selected')
+      end
+    end
+
+    context 'when there are no external comments' do
+      before do
+        # Update the existing ranking to have no external comments
+        ranking1.update_column(:external_comments, '')
+      end
+
+      it 'does not include the feedback section' do
+        expect(mail.body.encoded).not_to include('Feedback from Judges')
+      end
+    end
+
+    context 'when it is the final round' do
+      # Make sure the final round dates come after the first round end date
+      let(:final_round) { create(:judging_round, contest_instance: contest_instance, round_number: 2, completed: true,
+                                start_date: 1.week.ago, end_date: 2.days.ago) }
+
+      before do
+        # Assign the same judge to the final round
+        create(:round_judge_assignment, user: judge, judging_round: final_round)
+        # Create a ranking in the final round
+        create(:entry_ranking, entry: entry, user: judge, judging_round: final_round, rank: 1, selected_for_next_round: true)
+        # Allow the method call that checks for maximum round number
+        allow(contest_instance.judging_rounds).to receive(:maximum).with(:round_number).and_return(2)
+        # Use the final round for the mailer
+        @mail = described_class.entry_evaluation_notification(entry, final_round)
+      end
+
+      it 'indicates the entry is a finalist' do
+        expect(@mail.body.encoded).to include('selected as a finalist')
+      end
+    end
+  end
+end

--- a/spec/models/container_spec.rb
+++ b/spec/models/container_spec.rb
@@ -101,7 +101,8 @@ RSpec.describe Container do
           name: 'Test Container',
           department:,
           visibility:,
-          creator: user
+          creator: user,
+          contact_email: 'test@example.com'
         )
       end
 

--- a/spec/models/container_spec.rb
+++ b/spec/models/container_spec.rb
@@ -3,6 +3,7 @@
 # Table name: containers
 #
 #  id            :bigint           not null, primary key
+#  contact_email :string(255)
 #  name          :string(255)
 #  notes         :text(65535)
 #  created_at    :datetime         not null

--- a/spec/models/judging_round_spec.rb
+++ b/spec/models/judging_round_spec.rb
@@ -7,6 +7,8 @@
 #  completed                  :boolean          default(FALSE), not null
 #  emails_sent_count          :integer          default(0), not null
 #  end_date                   :datetime
+#  include_advancement_status :boolean          default(FALSE)
+#  include_average_ranking    :boolean          default(FALSE)
 #  min_external_comment_words :integer          default(0), not null
 #  min_internal_comment_words :integer          default(0), not null
 #  require_external_comments  :boolean          default(FALSE), not null

--- a/spec/models/judging_round_spec.rb
+++ b/spec/models/judging_round_spec.rb
@@ -5,6 +5,7 @@
 #  id                         :bigint           not null, primary key
 #  active                     :boolean          default(FALSE), not null
 #  completed                  :boolean          default(FALSE), not null
+#  emails_sent_count          :integer          default(0), not null
 #  end_date                   :datetime
 #  min_external_comment_words :integer          default(0), not null
 #  min_internal_comment_words :integer          default(0), not null

--- a/spec/system/email_preferences_spec.rb
+++ b/spec/system/email_preferences_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe 'Email Preferences', type: :system do
+  let(:department) { create(:department, name: 'Test Department') }
+  let(:admin_user) { create(:user, :axis_mundi) }
+  let(:container) { create(:container, name: 'Test Container', department: department, contact_email: 'admin@example.com') }
+  let(:contest_description) { create(:contest_description, name: 'Test Contest', container: container) }
+  let(:contest_instance) { create(:contest_instance, contest_description: contest_description, date_open: 4.months.ago, date_closed: 3.months.ago) }
+
+  # Create applicant user and entry
+  let(:applicant) { create(:user, email: 'applicant@example.com') }
+  let(:profile) { create(:profile, user: applicant) }
+  let(:entry) { create(:entry, title: 'Test Entry', profile: profile, contest_instance: contest_instance) }
+
+  # Create judge and rankings
+  let(:judge) {
+    judge = create(:user, :with_judge_role)
+    create(:judging_assignment, user: judge, contest_instance: contest_instance, active: true)
+    judge
+  }
+
+  # Create judging rounds
+  let(:judging_round) { create(:judging_round,
+                              contest_instance: contest_instance,
+                              round_number: 1,
+                              start_date: 50.days.ago,
+                              end_date: 30.days.ago,
+                              completed: true) }
+
+  before do
+    # Create rankings
+    create(:entry_ranking,
+           entry: entry,
+           judging_round: judging_round,
+           user: judge,
+           rank: 2,
+           external_comments: 'Good submission!',
+           selected_for_next_round: true)
+
+    # Assign the judge to the round
+    create(:round_judge_assignment, judging_round: judging_round, user: judge)
+
+    # Sign in as admin
+    login_as(admin_user, scope: :user)
+
+    # Mock the mailer to avoid actually sending emails in tests
+    allow(ResultsMailer).to receive(:entry_evaluation_notification).and_return(double(deliver_now: true, deliver_later: true))
+  end
+
+  it 'displays the email preferences form', :js do
+    # Visit the email preferences page directly
+    visit email_preferences_container_contest_description_contest_instance_path(
+      container,
+      contest_description,
+      contest_instance,
+      round_id: judging_round.id
+    )
+
+    # Verify we're on the email preferences page
+    expect(page).to have_content('Email Results Preferences')
+    expect(page).to have_content('Round 1 Email Content Options')
+
+    # Check that both checkboxes exist
+    expect(page).to have_field('include_average_ranking')
+    expect(page).to have_field('include_advancement_status')
+  end
+end

--- a/spec/system/judging_results_email_spec.rb
+++ b/spec/system/judging_results_email_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe 'Judging Results Email', type: :system do
+  let(:department) { create(:department, name: 'Test Department') }
+  let(:admin_user) { create(:user, :axis_mundi) }
+  let(:container) { create(:container, name: 'Test Container', department: department, contact_email: 'admin@example.com') }
+  let(:contest_description) { create(:contest_description, name: 'Test Contest', container: container) }
+  let(:contest_instance) { create(:contest_instance, contest_description: contest_description, date_open: 4.months.ago, date_closed: 3.months.ago) }
+
+  # Create applicant user and entry
+  let(:applicant) { create(:user, email: 'applicant@example.com') }
+  let(:profile) { create(:profile, user: applicant) }
+  let(:entry) { create(:entry, title: 'Test Entry', profile: profile, contest_instance: contest_instance) }
+
+  # Create judge and rankings
+  let(:judge) {
+    judge = create(:user, :with_judge_role)
+    create(:judging_assignment, user: judge, contest_instance: contest_instance, active: true)
+    judge
+  }
+
+  # Create judging rounds
+  let(:judging_round) { create(:judging_round,
+                              contest_instance: contest_instance,
+                              round_number: 1,
+                              start_date: 50.days.ago,
+                              end_date: 30.days.ago,
+                              completed: true) }
+
+  let(:incomplete_round) { create(:judging_round,
+                                 contest_instance: contest_instance,
+                                 round_number: 2,
+                                 start_date: 20.days.ago,
+                                 end_date: 10.days.ago,
+                                 completed: false) }
+
+  before do
+    # Create rankings
+    create(:entry_ranking,
+           entry: entry,
+           judging_round: judging_round,
+           user: judge,
+           rank: 2,
+           external_comments: 'Good submission!',
+           selected_for_next_round: true)
+
+    create(:entry_ranking,
+           entry: entry,
+           judging_round: incomplete_round,
+           user: judge)
+
+    # Assign the judge to the rounds
+    create(:round_judge_assignment, judging_round: judging_round, user: judge)
+    create(:round_judge_assignment, judging_round: incomplete_round, user: judge)
+
+    # Set up email counter
+    judging_round.update(emails_sent_count: 1)
+
+    # Sign in as admin
+    login_as(admin_user, scope: :user)
+
+    # Mock the mailer to avoid actually sending emails in tests
+    allow(ResultsMailer).to receive(:entry_evaluation_notification).and_return(double(deliver_now: true, deliver_later: true))
+  end
+
+  it 'shows completed round email counter and enables/disables buttons correctly', :js do
+    # Visit the contest instance page
+    visit container_contest_description_contest_instance_path(container, contest_description, contest_instance)
+
+    # Click the Judging Results tab
+    execute_script("document.getElementById('judging-results-tab').click()")
+    sleep 1
+
+    # Verify we can see both rounds
+    expect(page).to have_content('Round 1')
+    expect(page).to have_content('Round 2')
+
+    # Get all buttons with email text
+    buttons = page.all('button', text: /Email round \d+ results/)
+
+    # Check there are 2 buttons (one for each round)
+    expect(buttons.size).to eq(2)
+
+    # First button should be for round 1 and enabled
+    expect(buttons[0].text).to include('Email round 1 results')
+    expect(buttons[0]['disabled']).to eq('false').or eq(false).or be_nil
+
+    # Second button should be for round 2 and disabled
+    expect(buttons[1].text).to include('Email round 2 results')
+    expect(buttons[1]['disabled']).to eq('true').or eq(true)
+
+    # Check that the badge is displayed for round 1
+    expect(page).to have_content('Emails sent: 1 time')
+  end
+
+  it 'sends emails and increments counter when button is clicked', :js do
+    # Visit the contest instance page
+    visit container_contest_description_contest_instance_path(container, contest_description, contest_instance)
+
+    # Click the Judging Results tab
+    execute_script("document.getElementById('judging-results-tab').click()")
+    sleep 1
+
+    # Initial badge count
+    expect(page).to have_content('Emails sent: 1 time')
+
+    # Click the email button for round 1
+    accept_confirm do
+      click_button 'Email round 1 results'
+    end
+
+    # Verify success message appears
+    expect(page).to have_content('Successfully queued 1 evaluation result emails')
+
+    # Refresh the page to ensure we're seeing the latest data
+    visit current_path
+    execute_script("document.getElementById('judging-results-tab').click()")
+    sleep 1
+
+    # Verify counter increased
+    expect(page).to have_content('Emails sent: 2 times')
+  end
+end

--- a/spec/system/judging_results_email_spec.rb
+++ b/spec/system/judging_results_email_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'Judging Results Email', type: :system do
     allow(ResultsMailer).to receive(:entry_evaluation_notification).and_return(double(deliver_now: true, deliver_later: true))
   end
 
-  it 'shows completed round email counter and enables/disables buttons correctly', :js do
+  it 'shows completed round email counter and enables/disables links correctly', :js do
     # Visit the contest instance page
     visit container_contest_description_contest_instance_path(container, contest_description, contest_instance)
 
@@ -75,25 +75,25 @@ RSpec.describe 'Judging Results Email', type: :system do
     expect(page).to have_content('Round 1')
     expect(page).to have_content('Round 2')
 
-    # Get all buttons with email text
-    buttons = page.all('button', text: /Email round \d+ results/)
+    # Get all links with email text
+    links = page.all('a', text: /Email round \d+ results/)
 
-    # Check there are 2 buttons (one for each round)
-    expect(buttons.size).to eq(2)
+    # Check there are 2 links (one for each round)
+    expect(links.size).to eq(2)
 
-    # First button should be for round 1 and enabled
-    expect(buttons[0].text).to include('Email round 1 results')
-    expect(buttons[0]['disabled']).to eq('false').or eq(false).or be_nil
+    # First link should be for round 1 and enabled
+    expect(links[0].text).to include('Email round 1 results')
+    expect(links[0]['disabled']).to be_nil
 
-    # Second button should be for round 2 and disabled
-    expect(buttons[1].text).to include('Email round 2 results')
-    expect(buttons[1]['disabled']).to eq('true').or eq(true)
+    # Second link should be for round 2 and disabled
+    expect(links[1].text).to include('Email round 2 results')
+    expect(links[1]['disabled']).to eq('disabled')
 
     # Check that the badge is displayed for round 1
     expect(page).to have_content('Emails sent: 1 time')
   end
 
-  it 'sends emails and increments counter when button is clicked', :js do
+  it 'navigates to email preferences and sends emails', :js do
     # Visit the contest instance page
     visit container_contest_description_contest_instance_path(container, contest_description, contest_instance)
 
@@ -104,9 +104,16 @@ RSpec.describe 'Judging Results Email', type: :system do
     # Initial badge count
     expect(page).to have_content('Emails sent: 1 time')
 
-    # Click the email button for round 1
+    # Click the email link for round 1
+    click_link 'Email round 1 results'
+
+    # Verify we're on the email preferences page
+    expect(page).to have_content('Email Results Preferences')
+    expect(page).to have_content('Round 1 Email Content Options')
+
+    # Submit the form with default preferences
     accept_confirm do
-      click_button 'Email round 1 results'
+      click_button 'Send Emails'
     end
 
     # Verify success message appears


### PR DESCRIPTION
- Implement RSpec tests for the email_preferences action, ensuring proper rendering of the email preferences template and correct assignment of the judging round.
- Add tests for handling non-existent and incomplete judging rounds, verifying appropriate redirection and alert messages.
- Enhance the send_round_results action tests to check for updates to email preferences based on user input, ensuring preferences are preserved when not provided.
- Introduce system tests for the email preferences form, confirming the presence of checkboxes and the correct display of email content options based on user selections.