### PR TITLE
LRA-1041-lsa-evaluate-add-a-check-to-confirm-a-user-is-creating-a-contest-instance-or-a-contest-description-and-it-is-not-set-to-active

### DIFF
--- a/app/controllers/contest_descriptions_controller.rb
+++ b/app/controllers/contest_descriptions_controller.rb
@@ -88,7 +88,10 @@ class ContestDescriptionsController < ApplicationController
         format.turbo_stream {
           render turbo_stream: turbo_stream.replace('contest_description_form', partial: 'contest_descriptions/form', locals: { contest_description: @contest_description }), status: :unprocessable_entity
         }
-        format.html { render action_name.to_sym, status: :unprocessable_entity }
+        format.html {
+          template = action_name == 'create' ? :new : :edit
+          render template, status: :unprocessable_entity
+        }
       end
     end
   end

--- a/app/javascript/controllers/contest_activation_controller.js
+++ b/app/javascript/controllers/contest_activation_controller.js
@@ -34,6 +34,9 @@ export default class extends Controller {
       return
     }
 
+    // Prevent the default form submission temporarily
+    event.preventDefault()
+
     // Show confirmation dialog synchronously
     const message = this.confirmMessageValue ||
       "This contest will be created as inactive. Would you like to make it active now? " +
@@ -50,8 +53,14 @@ export default class extends Controller {
       console.log("User cancelled, checkbox remains unchecked")
     }
 
-    // Let the normal form submission proceed
-    console.log("Allowing normal form submission to proceed")
+    // Now submit the form using requestSubmit to trigger proper form validation
+    console.log("Submitting form using requestSubmit")
+    if (this.submitButtonTarget.form.requestSubmit) {
+      this.submitButtonTarget.form.requestSubmit(this.submitButtonTarget)
+    } else {
+      // Fallback for older browsers
+      this.submitButtonTarget.form.submit()
+    }
   }
 
   checkActivation(event) {

--- a/app/javascript/controllers/contest_activation_controller.js
+++ b/app/javascript/controllers/contest_activation_controller.js
@@ -1,0 +1,60 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["activeCheckbox", "submitButton"]
+  static values = {
+    isNewRecord: Boolean,
+    confirmMessage: String
+  }
+
+  connect() {
+    console.log("contest-activation controller connected")
+    console.log("isNewRecord:", this.isNewRecordValue)
+    console.log("hasSubmitButtonTarget:", this.hasSubmitButtonTarget)
+    if (this.isNewRecordValue && this.hasSubmitButtonTarget) {
+      this.submitButtonTarget.addEventListener('click', this.handleButtonClick.bind(this))
+      console.log("Event listener added to submit button")
+    }
+  }
+
+  handleButtonClick(event) {
+    console.log("=== handleButtonClick called ===")
+    console.log("isNewRecord:", this.isNewRecordValue)
+    console.log("checkbox checked:", this.activeCheckboxTarget.checked)
+
+    // Only prompt for new records (creation)
+    if (!this.isNewRecordValue) {
+      console.log("Not a new record, returning")
+      return
+    }
+
+    // If active checkbox is already checked, proceed normally
+    if (this.activeCheckboxTarget.checked) {
+      console.log("Checkbox already checked, proceeding normally")
+      return
+    }
+
+    // Show confirmation dialog synchronously
+    const message = this.confirmMessageValue ||
+      "This contest will be created as inactive. Would you like to make it active now? " +
+      "Active contests allow administrators to manage entries and judges to provide feedback during their assigned periods."
+
+    const userConfirmed = confirm(message)
+    console.log("User confirmed:", userConfirmed)
+
+    if (userConfirmed) {
+      // User wants to activate - check the checkbox
+      this.activeCheckboxTarget.checked = true
+      console.log("Checkbox set to checked")
+    } else {
+      console.log("User cancelled, checkbox remains unchecked")
+    }
+
+    // Let the normal form submission proceed
+    console.log("Allowing normal form submission to proceed")
+  }
+
+  checkActivation(event) {
+    // This method is no longer used
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,6 +19,9 @@ application.register("comments-counter", CommentsCounterController)
 import ConfirmController from "./confirm_controller"
 application.register("confirm", ConfirmController)
 
+import ContestActivationController from "./contest_activation_controller"
+application.register("contest-activation", ContestActivationController)
+
 import DropdownController from "./dropdown_controller"
 application.register("dropdown", DropdownController)
 

--- a/app/views/contest_descriptions/_form.html.erb
+++ b/app/views/contest_descriptions/_form.html.erb
@@ -1,7 +1,11 @@
 <div id="contest_description_form" class="mb-1">
   <%= simple_form_for([@container, @contest_description],
     html: {
-      id: 'new_contest_description_form'
+      id: 'new_contest_description_form',
+      data: {
+        controller: "contest-activation",
+        contest_activation_is_new_record_value: @contest_description.new_record?
+      }
     }) do |f| %>
     <%= f.error_notification %>
     <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
@@ -12,11 +16,15 @@
       <%= f.input :eligibility_rules, as: :rich_text_area, hint: "These notes display on the applicant entry form and on the assigned judges' dashboard" %>
       <%= f.input :notes, as: :rich_text_area, hint: "These notes are not visible on the applicant entry form" %>
       <%= f.input :short_name %>
-      <%= f.input :active, hint: "Toggle this checkbox to make the contest active. When active, administrators will be able to manage the submitted entries. Judges, during their assigned judging period, will be able to view the entries and provide feedback. Note that the contest's instances availabilty for submissions will follow the visibility settings based on specific dates configured in each contest instance. If this checkbox is unchecked, the contest and its instances will remain inactive and hidden from evaluation workflows." %>
+      <%= f.input :active,
+          hint: "Toggle this checkbox to make the contest active. When active, administrators will be able to manage the submitted entries. Judges, during their assigned judging period, will be able to view the entries and provide feedback. Note that the contest's instances availabilty for submissions will follow the visibility settings based on specific dates configured in each contest instance. If this checkbox is unchecked, the contest and its instances will remain inactive and hidden from evaluation workflows.",
+          input_html: { data: { contest_activation_target: "activeCheckbox" } } %>
     </div>
 
     <div class="form-actions">
-      <%= f.button :submit, (f.object.new_record? ? "Create Contest" : "Update Contest"), class: "btn btn-primary" %>
+      <%= f.button :submit, (f.object.new_record? ? "Create Contest" : "Update Contest"),
+          class: "btn btn-primary",
+          data: { contest_activation_target: "submitButton" } %>
       <%= link_to "Cancel", (f.object.new_record? ? container_path(@container) : container_contest_description_contest_instances_path(@container, @contest_description)), class: "text-danger link_to" %>
     </div>
   <% end %>

--- a/app/views/contest_instances/_form.html.erb
+++ b/app/views/contest_instances/_form.html.erb
@@ -1,16 +1,20 @@
 <%= simple_form_for([@container, @contest_description, @contest_instance],
     html: {
       data: {
-        controller: "form-validation",
+        controller: "form-validation contest-activation",
         action: "submit->form-validation#submitForm",
-        form_validation_target: "form"
+        form_validation_target: "form",
+        contest_activation_is_new_record_value: @contest_instance.new_record?,
+        contest_activation_confirm_message_value: "This contest instance will be created as inactive. Would you like to make it active now? Active instances accept entries during the specified open and close dates."
       }
     }) do |f| %>
   <%= f.error_notification %>
   <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
   <div class="form-inputs">
-    <%= f.input :active, hint: "Specify whether this contest is currently accepting entries during the contest open and close dates specified below." %>
+    <%= f.input :active,
+        hint: "Specify whether this contest is currently accepting entries during the contest open and close dates specified below.",
+        input_html: { data: { contest_activation_target: "activeCheckbox" } } %>
     <%= f.association :contest_description, label_method: :name %>
     <div class="row">
       <div class="col-md-6">
@@ -120,7 +124,9 @@
   </div>
 
   <div class="form-actions py-2">
-    <%= f.button :submit, class: "btn btn-primary" %>
+    <%= f.button :submit,
+        class: "btn btn-primary",
+        data: { contest_activation_target: "submitButton" } %>
     <%= link_to "Cancel", (f.object.new_record? ? container_contest_description_contest_instances_path(@container, @contest_description) : container_contest_description_contest_instance_path(@container, @contest_description, @contest_instance)), class: "text-danger link_to" %>
   </div>
 <% end %>

--- a/spec/controllers/contest_descriptions_controller_spec.rb
+++ b/spec/controllers/contest_descriptions_controller_spec.rb
@@ -1,0 +1,203 @@
+require 'rails_helper'
+
+RSpec.describe ContestDescriptionsController, type: :controller do
+  let(:department) { create(:department) }
+  let(:user) { create(:user, :axis_mundi) }
+  let(:container) { create(:container, department: department) }
+  let(:contest_description) { create(:contest_description, container: container) }
+
+  before do
+    sign_in user
+  end
+
+  describe 'GET #new' do
+    it 'assigns a new contest description' do
+      get :new, params: { container_id: container.id }
+      expect(assigns(:contest_description)).to be_a_new(ContestDescription)
+      expect(assigns(:contest_description).container).to eq(container)
+    end
+
+    it 'renders the new template' do
+      get :new, params: { container_id: container.id }
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST #create' do
+    let(:valid_attributes) do
+      {
+        name: 'Test Contest',
+        created_by: user.email,
+        eligibility_rules: 'Test rules',
+        notes: 'Test notes',
+        short_name: 'test',
+        active: true
+      }
+    end
+
+    let(:invalid_attributes) do
+      {
+        name: '', # Required field
+        created_by: user.email
+      }
+    end
+
+    context 'with valid parameters' do
+      it 'creates a new contest description' do
+        expect {
+          post :create, params: {
+            container_id: container.id,
+            contest_description: valid_attributes
+          }
+        }.to change(ContestDescription, :count).by(1)
+      end
+
+      it 'redirects to the container page with success notice' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description: valid_attributes
+        }
+        expect(response).to redirect_to(container_path(container))
+        expect(flash[:notice]).to be_present
+      end
+
+      it 'creates active contest description when active is true' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description: valid_attributes.merge(active: true)
+        }
+        created_contest = ContestDescription.last
+        expect(created_contest.active).to be true
+      end
+
+      it 'creates inactive contest description when active is false' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description: valid_attributes.merge(active: false)
+        }
+        created_contest = ContestDescription.last
+        expect(created_contest.active).to be false
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new contest description' do
+        expect {
+          post :create, params: {
+            container_id: container.id,
+            contest_description: invalid_attributes
+          }
+        }.not_to change(ContestDescription, :count)
+      end
+
+      it 'renders the new template with errors' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description: invalid_attributes
+        }
+        expect(response).to render_template(:new)
+        expect(response.status).to eq(422)
+      end
+
+      it 'assigns the contest description with errors' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description: invalid_attributes
+        }
+        expect(assigns(:contest_description)).to be_a(ContestDescription)
+        expect(assigns(:contest_description).errors).to be_present
+      end
+    end
+
+    context 'with Turbo Stream requests' do
+      it 'responds with turbo stream for successful creation' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description: valid_attributes
+        }, as: :turbo_stream
+
+        expect(response.status).to eq(302) # Redirect
+      end
+
+      it 'responds with turbo stream for validation errors' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description: invalid_attributes
+        }, as: :turbo_stream
+
+        expect(response.status).to eq(422)
+        expect(response.content_type).to include('text/vnd.turbo-stream.html')
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    let(:update_attributes) do
+      {
+        name: 'Updated Contest',
+        active: false
+      }
+    end
+
+    context 'with valid parameters' do
+      it 'updates the contest description' do
+        put :update, params: {
+          container_id: container.id,
+          id: contest_description.id,
+          contest_description: update_attributes
+        }
+        contest_description.reload
+        expect(contest_description.name).to eq('Updated Contest')
+      end
+
+      it 'redirects to the container page' do
+        put :update, params: {
+          container_id: container.id,
+          id: contest_description.id,
+          contest_description: update_attributes
+        }
+        expect(response).to redirect_to(container_path(container))
+      end
+    end
+
+    context 'when trying to deactivate with active instances' do
+      let!(:active_instance) { create(:contest_instance, contest_description: contest_description, active: true) }
+
+      it 'prevents deactivation and shows error' do
+        put :update, params: {
+          container_id: container.id,
+          id: contest_description.id,
+          contest_description: { active: false }
+        }
+
+        expect(response.status).to eq(422)
+        expect(flash[:alert]).to include('Cannot deactivate contest description while it has active instances')
+        contest_description.reload
+        expect(contest_description.active).to be true # Should remain active
+      end
+
+      it 'responds with turbo stream for active instance prevention' do
+        put :update, params: {
+          container_id: container.id,
+          id: contest_description.id,
+          contest_description: { active: false }
+        }, as: :turbo_stream
+
+        expect(response.status).to eq(422)
+        expect(response.content_type).to include('text/vnd.turbo-stream.html')
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'renders the edit template with errors' do
+        put :update, params: {
+          container_id: container.id,
+          id: contest_description.id,
+          contest_description: { name: '' } # Invalid - name is required
+        }
+        expect(response).to render_template(:edit)
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+end

--- a/spec/controllers/contest_descriptions_controller_spec.rb
+++ b/spec/controllers/contest_descriptions_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ContestDescriptionsController, type: :controller do
   let(:department) { create(:department) }
   let(:user) { create(:user, :axis_mundi) }
   let(:container) { create(:container, department: department) }
-  let(:contest_description) { create(:contest_description, container: container) }
+  let(:contest_description) { create(:contest_description, :active, container: container) }
 
   before do
     sign_in user
@@ -167,7 +167,7 @@ RSpec.describe ContestDescriptionsController, type: :controller do
         put :update, params: {
           container_id: container.id,
           id: contest_description.id,
-          contest_description: { active: false }
+          contest_description: { active: "0" }
         }
 
         expect(response.status).to eq(422)
@@ -180,7 +180,7 @@ RSpec.describe ContestDescriptionsController, type: :controller do
         put :update, params: {
           container_id: container.id,
           id: contest_description.id,
-          contest_description: { active: false }
+          contest_description: { active: "0" }
         }, as: :turbo_stream
 
         expect(response.status).to eq(422)

--- a/spec/controllers/contest_instances_controller_create_spec.rb
+++ b/spec/controllers/contest_instances_controller_create_spec.rb
@@ -1,0 +1,255 @@
+require 'rails_helper'
+
+RSpec.describe ContestInstancesController, type: :controller do
+  let(:department) { create(:department) }
+  let(:user) { create(:user, :axis_mundi) }
+  let(:container) { create(:container, department: department) }
+  let(:contest_description) { create(:contest_description, container: container) }
+
+  before do
+    sign_in user
+  end
+
+  describe 'POST #create' do
+    let(:valid_attributes) do
+      {
+        active: true,
+        date_open: 1.week.from_now,
+        date_closed: 2.weeks.from_now,
+        notes: 'Test instance notes',
+        maximum_number_entries_per_applicant: 3,
+        require_pen_name: false,
+        require_campus_employment_info: false,
+        require_finaid_info: false,
+        created_by: user.email
+      }
+    end
+
+    let(:invalid_attributes) do
+      {
+        active: true,
+        date_open: 2.weeks.from_now,
+        date_closed: 1.week.from_now, # Invalid: close date before open date
+        notes: 'Test instance notes'
+      }
+    end
+
+    context 'with valid parameters' do
+      it 'creates a new contest instance' do
+        expect {
+          post :create, params: {
+            container_id: container.id,
+            contest_description_id: contest_description.id,
+            contest_instance: valid_attributes
+          }
+        }.to change(ContestInstance, :count).by(1)
+      end
+
+      it 'redirects to the contest instance page with success notice' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          contest_instance: valid_attributes
+        }
+
+        created_instance = ContestInstance.last
+        expect(response).to redirect_to(
+          container_contest_description_contest_instance_path(container, contest_description, created_instance)
+        )
+        expect(flash[:notice]).to be_present
+      end
+
+      it 'creates active contest instance when active is true' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          contest_instance: valid_attributes.merge(active: true)
+        }
+
+        created_instance = ContestInstance.last
+        expect(created_instance.active).to be true
+      end
+
+      it 'creates inactive contest instance when active is false' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          contest_instance: valid_attributes.merge(active: false)
+        }
+
+        created_instance = ContestInstance.last
+        expect(created_instance.active).to be false
+      end
+
+      it 'sets the created_by field to current user email' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          contest_instance: valid_attributes
+        }
+
+        created_instance = ContestInstance.last
+        expect(created_instance.created_by).to eq(user.email)
+      end
+
+      it 'associates contest instance with correct contest description' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          contest_instance: valid_attributes
+        }
+
+        created_instance = ContestInstance.last
+        expect(created_instance.contest_description).to eq(contest_description)
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new contest instance' do
+        expect {
+          post :create, params: {
+            container_id: container.id,
+            contest_description_id: contest_description.id,
+            contest_instance: invalid_attributes
+          }
+        }.not_to change(ContestInstance, :count)
+      end
+
+      it 'renders the new template with errors' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          contest_instance: invalid_attributes
+        }
+
+        expect(response).to render_template(:new)
+        expect(response.status).to eq(422)
+      end
+
+      it 'assigns the contest instance with errors' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          contest_instance: invalid_attributes
+        }
+
+        expect(assigns(:contest_instance)).to be_a(ContestInstance)
+        expect(assigns(:contest_instance).errors).to be_present
+      end
+    end
+
+    context 'activation workflow integration' do
+      it 'processes activation parameter correctly when coming from JavaScript workflow' do
+        # Simulate the JavaScript workflow setting active to true after confirmation
+        post :create, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          contest_instance: valid_attributes.merge(active: true) # JS would set this to true
+        }
+
+        created_instance = ContestInstance.last
+        expect(created_instance.active).to be true
+        expect(response).to be_redirect
+      end
+
+      it 'respects user choice to keep instance inactive' do
+        # Simulate user choosing to keep instance inactive in JavaScript workflow
+        post :create, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          contest_instance: valid_attributes.merge(active: false) # JS would leave this as false
+        }
+
+        created_instance = ContestInstance.last
+        expect(created_instance.active).to be false
+        expect(response).to be_redirect
+      end
+    end
+
+    context 'with categories and class levels' do
+      let!(:category1) { create(:category, kind: 'Fiction') }
+      let!(:category2) { create(:category, kind: 'Poetry') }
+      let!(:class_level1) { create(:class_level, name: 'Undergraduate') }
+      let!(:class_level2) { create(:class_level, name: 'Graduate') }
+
+      it 'associates selected categories with contest instance' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          contest_instance: valid_attributes.merge(
+            category_ids: [category1.id, category2.id]
+          )
+        }
+
+        created_instance = ContestInstance.last
+        expect(created_instance.categories).to include(category1, category2)
+      end
+
+      it 'associates selected class levels with contest instance' do
+        post :create, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          contest_instance: valid_attributes.merge(
+            class_level_ids: [class_level1.id, class_level2.id]
+          )
+        }
+
+        created_instance = ContestInstance.last
+        expect(created_instance.class_levels).to include(class_level1, class_level2)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    let!(:contest_instance) { create(:contest_instance, contest_description: contest_description, active: false) }
+
+    let(:update_attributes) do
+      {
+        active: true,
+        notes: 'Updated notes'
+      }
+    end
+
+    context 'with valid parameters' do
+      it 'updates the contest instance' do
+        put :update, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          id: contest_instance.id,
+          contest_instance: update_attributes
+        }
+
+        contest_instance.reload
+        expect(contest_instance.active).to be true
+        expect(contest_instance.notes).to eq('Updated notes')
+      end
+
+      it 'redirects to the contest instance page' do
+        put :update, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          id: contest_instance.id,
+          contest_instance: update_attributes
+        }
+
+        expect(response).to redirect_to(
+          container_contest_description_contest_instance_path(container, contest_description, contest_instance)
+        )
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'renders the edit template with errors' do
+        put :update, params: {
+          container_id: container.id,
+          contest_description_id: contest_description.id,
+          id: contest_instance.id,
+          contest_instance: { date_closed: 1.day.ago } # Invalid: past date
+        }
+
+        expect(response).to render_template(:edit)
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+end

--- a/spec/controllers/contest_instances_controller_create_spec.rb
+++ b/spec/controllers/contest_instances_controller_create_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe ContestInstancesController, type: :controller do
   let(:department) { create(:department) }
   let(:user) { create(:user, :axis_mundi) }
   let(:container) { create(:container, department: department) }
-  let(:contest_description) { create(:contest_description, container: container) }
+  let(:contest_description) { create(:contest_description, :active, container: container) }
+  let!(:category) { create(:category, kind: 'Fiction_Base') }
+  let!(:class_level) { create(:class_level, name: 'Undergraduate_Base') }
 
   before do
     sign_in user
@@ -21,7 +23,9 @@ RSpec.describe ContestInstancesController, type: :controller do
         require_pen_name: false,
         require_campus_employment_info: false,
         require_finaid_info: false,
-        created_by: user.email
+        created_by: user.email,
+        category_ids: [category.id],
+        class_level_ids: [class_level.id]
       }
     end
 

--- a/spec/javascript/controllers/contest_activation_controller.test.js
+++ b/spec/javascript/controllers/contest_activation_controller.test.js
@@ -1,0 +1,246 @@
+import { Application } from "@hotwired/stimulus"
+import ContestActivationController from "../../../app/javascript/controllers/contest_activation_controller"
+
+describe("ContestActivationController", () => {
+  let application
+  let container
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register("contest-activation", ContestActivationController)
+  })
+
+  afterEach(() => {
+    document.body.removeChild(container)
+    application.stop()
+  })
+
+  describe("when creating a new record", () => {
+    beforeEach(() => {
+      container.innerHTML = `
+        <form data-controller="contest-activation"
+              data-contest-activation-is-new-record-value="true">
+          <input type="checkbox"
+                 data-contest-activation-target="activeCheckbox"
+                 name="contest_description[active]">
+          <button type="submit"
+                  data-contest-activation-target="submitButton">Create Contest</button>
+        </form>
+      `
+    })
+
+    describe("when active checkbox is checked", () => {
+      it("submits form normally without confirmation", () => {
+        const checkbox = container.querySelector('[data-contest-activation-target="activeCheckbox"]')
+        const submitButton = container.querySelector('[data-contest-activation-target="submitButton"]')
+        const form = container.querySelector('form')
+
+        checkbox.checked = true
+
+        // Mock form submission
+        let formSubmitted = false
+        form.addEventListener('submit', (e) => {
+          e.preventDefault()
+          formSubmitted = true
+        })
+
+        // Click submit button
+        const clickEvent = new Event('click', { cancelable: true })
+        submitButton.dispatchEvent(clickEvent)
+
+        expect(clickEvent.defaultPrevented).toBe(false)
+        expect(formSubmitted).toBe(true)
+      })
+    })
+
+    describe("when active checkbox is not checked", () => {
+      it("shows confirmation dialog and activates if user confirms", () => {
+        const checkbox = container.querySelector('[data-contest-activation-target="activeCheckbox"]')
+        const submitButton = container.querySelector('[data-contest-activation-target="submitButton"]')
+        const form = container.querySelector('form')
+
+        checkbox.checked = false
+
+        // Mock window.confirm to return true (user confirms)
+        const originalConfirm = window.confirm
+        let confirmMessage = ''
+        window.confirm = (message) => {
+          confirmMessage = message
+          return true
+        }
+
+        // Mock form submission
+        let formSubmitted = false
+        form.addEventListener('submit', (e) => {
+          e.preventDefault()
+          formSubmitted = true
+        })
+
+        try {
+          // Click submit button
+          const clickEvent = new Event('click', { cancelable: true })
+          submitButton.dispatchEvent(clickEvent)
+
+          // Check that confirmation was shown
+          expect(confirmMessage).toContain('This contest will be created as inactive')
+          expect(confirmMessage).toContain('Would you like to make it active now?')
+
+          // Check that checkbox was checked after confirmation
+          expect(checkbox.checked).toBe(true)
+
+          // Form should be submitted
+          expect(formSubmitted).toBe(true)
+        } finally {
+          window.confirm = originalConfirm
+        }
+      })
+
+      it("keeps checkbox unchecked if user cancels", () => {
+        const checkbox = container.querySelector('[data-contest-activation-target="activeCheckbox"]')
+        const submitButton = container.querySelector('[data-contest-activation-target="submitButton"]')
+        const form = container.querySelector('form')
+
+        checkbox.checked = false
+
+        // Mock window.confirm to return false (user cancels)
+        const originalConfirm = window.confirm
+        window.confirm = () => false
+
+        // Mock form submission
+        let formSubmitted = false
+        form.addEventListener('submit', (e) => {
+          e.preventDefault()
+          formSubmitted = true
+        })
+
+        try {
+          // Click submit button
+          const clickEvent = new Event('click', { cancelable: true })
+          submitButton.dispatchEvent(clickEvent)
+
+          // Check that checkbox remains unchecked
+          expect(checkbox.checked).toBe(false)
+
+          // Form should still be submitted
+          expect(formSubmitted).toBe(true)
+        } finally {
+          window.confirm = originalConfirm
+        }
+      })
+
+      it("uses custom confirmation message when provided", () => {
+        container.innerHTML = `
+          <form data-controller="contest-activation"
+                data-contest-activation-is-new-record-value="true"
+                data-contest-activation-confirm-message-value="Custom message for testing">
+            <input type="checkbox"
+                   data-contest-activation-target="activeCheckbox"
+                   name="contest_description[active]">
+            <button type="submit"
+                    data-contest-activation-target="submitButton">Create Contest</button>
+          </form>
+        `
+
+        const checkbox = container.querySelector('[data-contest-activation-target="activeCheckbox"]')
+        const submitButton = container.querySelector('[data-contest-activation-target="submitButton"]')
+
+        checkbox.checked = false
+
+        // Mock window.confirm
+        const originalConfirm = window.confirm
+        let confirmMessage = ''
+        window.confirm = (message) => {
+          confirmMessage = message
+          return true
+        }
+
+        try {
+          // Click submit button
+          const clickEvent = new Event('click', { cancelable: true })
+          submitButton.dispatchEvent(clickEvent)
+
+          expect(confirmMessage).toBe('Custom message for testing')
+        } finally {
+          window.confirm = originalConfirm
+        }
+      })
+    })
+  })
+
+  describe("when editing an existing record", () => {
+    beforeEach(() => {
+      container.innerHTML = `
+        <form data-controller="contest-activation"
+              data-contest-activation-is-new-record-value="false">
+          <input type="checkbox"
+                 data-contest-activation-target="activeCheckbox"
+                 name="contest_description[active]">
+          <button type="submit"
+                  data-contest-activation-target="submitButton">Update Contest</button>
+        </form>
+      `
+    })
+
+    it("submits form normally without any confirmation", () => {
+      const checkbox = container.querySelector('[data-contest-activation-target="activeCheckbox"]')
+      const submitButton = container.querySelector('[data-contest-activation-target="submitButton"]')
+      const form = container.querySelector('form')
+
+      checkbox.checked = false // Even when unchecked
+
+      // Mock form submission
+      let formSubmitted = false
+      form.addEventListener('submit', (e) => {
+        e.preventDefault()
+        formSubmitted = true
+      })
+
+      // Mock window.confirm (should not be called)
+      const originalConfirm = window.confirm
+      let confirmCalled = false
+      window.confirm = () => {
+        confirmCalled = true
+        return true
+      }
+
+      try {
+        // Click submit button
+        const clickEvent = new Event('click', { cancelable: true })
+        submitButton.dispatchEvent(clickEvent)
+
+        expect(confirmCalled).toBe(false)
+        expect(formSubmitted).toBe(true)
+        expect(clickEvent.defaultPrevented).toBe(false)
+      } finally {
+        window.confirm = originalConfirm
+      }
+    })
+  })
+
+  describe("controller connection", () => {
+    it("logs connection message", () => {
+      const originalLog = console.log
+      let logMessage = ''
+      console.log = (message) => {
+        logMessage = message
+      }
+
+      try {
+        container.innerHTML = `
+          <form data-controller="contest-activation"
+                data-contest-activation-is-new-record-value="true">
+            <input type="checkbox" data-contest-activation-target="activeCheckbox">
+            <button type="submit" data-contest-activation-target="submitButton">Submit</button>
+          </form>
+        `
+
+        expect(logMessage).toBe('contest-activation controller connected')
+      } finally {
+        console.log = originalLog
+      }
+    })
+  })
+})

--- a/spec/system/contest_activation_spec.rb
+++ b/spec/system/contest_activation_spec.rb
@@ -1,0 +1,231 @@
+require 'rails_helper'
+
+RSpec.describe 'Contest Activation Workflow', type: :system, js: true do
+  let(:department) { create(:department) }
+  let(:user) { create(:user, :axis_mundi) }
+  let(:container) { create(:container, department: department) }
+
+  before do
+    login_as(user, scope: :user)
+  end
+
+  describe 'Contest Description activation workflow' do
+    context 'when creating a new contest description' do
+      it 'shows confirmation dialog when active checkbox is unchecked' do
+        visit new_container_contest_description_path(container)
+
+        fill_in 'Name', with: 'Test Contest'
+        fill_in 'Short name', with: 'test'
+
+        # Ensure active checkbox is unchecked
+        uncheck 'Active'
+
+        # Mock the confirm dialog to accept
+        page.execute_script("window.confirm = function() { return true; }")
+
+        click_button 'Create Contest'
+
+        # Should create an active contest (checkbox was checked by JS)
+        expect(page).to have_current_path(container_path(container))
+        expect(page).to have_content('Contest description was successfully created')
+
+        created_contest = ContestDescription.last
+        expect(created_contest.active).to be true
+        expect(created_contest.name).to eq('Test Contest')
+      end
+
+      it 'keeps contest inactive when user cancels confirmation' do
+        visit new_container_contest_description_path(container)
+
+        fill_in 'Name', with: 'Test Contest'
+        fill_in 'Short name', with: 'test'
+
+        # Ensure active checkbox is unchecked
+        uncheck 'Active'
+
+        # Mock the confirm dialog to cancel
+        page.execute_script("window.confirm = function() { return false; }")
+
+        click_button 'Create Contest'
+
+        # Should create an inactive contest
+        expect(page).to have_current_path(container_path(container))
+        expect(page).to have_content('Contest description was successfully created')
+
+        created_contest = ContestDescription.last
+        expect(created_contest.active).to be false
+        expect(created_contest.name).to eq('Test Contest')
+      end
+
+      it 'submits normally when active checkbox is already checked' do
+        visit new_container_contest_description_path(container)
+
+        fill_in 'Name', with: 'Test Contest'
+        fill_in 'Short name', with: 'test'
+
+        # Keep active checkbox checked
+        check 'Active'
+
+        # Set up a spy to ensure confirm is not called
+        page.execute_script("window.confirmCalled = false; window.confirm = function() { window.confirmCalled = true; return true; }")
+
+        click_button 'Create Contest'
+
+        # Should create an active contest without showing confirmation
+        expect(page).to have_current_path(container_path(container))
+        expect(page).to have_content('Contest description was successfully created')
+
+        created_contest = ContestDescription.last
+        expect(created_contest.active).to be true
+
+        # Confirm should not have been called
+        confirm_called = page.execute_script("return window.confirmCalled")
+        expect(confirm_called).to be false
+      end
+
+      it 'displays validation errors properly when form is invalid' do
+        visit new_container_contest_description_path(container)
+
+        # Leave name blank (required field)
+        fill_in 'Short name', with: 'test'
+        uncheck 'Active'
+
+        # Mock the confirm dialog to accept
+        page.execute_script("window.confirm = function() { return true; }")
+
+        click_button 'Create Contest'
+
+        # Should stay on new page with errors
+        expect(page).to have_current_path(container_contest_descriptions_path(container))
+        expect(page).to have_content("Name can't be blank")
+        expect(ContestDescription.count).to eq(0)
+      end
+    end
+
+    context 'when editing an existing contest description' do
+      let!(:contest_description) { create(:contest_description, container: container, active: true) }
+
+      it 'does not show confirmation dialog even when unchecking active' do
+        visit edit_container_contest_description_path(container, contest_description)
+
+        uncheck 'Active'
+
+        # Set up a spy to ensure confirm is not called
+        page.execute_script("window.confirmCalled = false; window.confirm = function() { window.confirmCalled = true; return true; }")
+
+        click_button 'Update Contest'
+
+        # Should update without confirmation
+        expect(page).to have_current_path(container_path(container))
+        expect(page).to have_content('Contest description was successfully updated')
+
+        # Confirm should not have been called
+        confirm_called = page.execute_script("return window.confirmCalled")
+        expect(confirm_called).to be false
+
+        contest_description.reload
+        expect(contest_description.active).to be false
+      end
+    end
+  end
+
+  describe 'Contest Instance activation workflow' do
+    let!(:contest_description) { create(:contest_description, container: container) }
+
+    context 'when creating a new contest instance' do
+      it 'shows confirmation dialog when active checkbox is unchecked' do
+        visit new_container_contest_description_contest_instance_path(container, contest_description)
+
+        # Fill in required fields
+        fill_in 'contest_instance_date_open', with: 1.week.from_now.strftime('%Y-%m-%dT%H:%M')
+        fill_in 'contest_instance_date_closed', with: 2.weeks.from_now.strftime('%Y-%m-%dT%H:%M')
+
+        # Ensure active checkbox is unchecked
+        uncheck 'Active'
+
+        # Mock the confirm dialog to accept
+        page.execute_script("window.confirm = function(message) { window.lastConfirmMessage = message; return true; }")
+
+        click_button 'Create Contest instance'
+
+        # Should create an active contest instance
+        expect(page).to have_content('Contest instance was successfully created')
+
+        created_instance = contest_description.contest_instances.last
+        expect(created_instance.active).to be true
+
+        # Check that the correct message was shown
+        confirm_message = page.execute_script("return window.lastConfirmMessage")
+        expect(confirm_message).to include('This contest instance will be created as inactive')
+        expect(confirm_message).to include('Active instances accept entries during the specified open and close dates')
+      end
+
+      it 'keeps instance inactive when user cancels confirmation' do
+        visit new_container_contest_description_contest_instance_path(container, contest_description)
+
+        fill_in 'contest_instance_date_open', with: 1.week.from_now.strftime('%Y-%m-%dT%H:%M')
+        fill_in 'contest_instance_date_closed', with: 2.weeks.from_now.strftime('%Y-%m-%dT%H:%M')
+        uncheck 'Active'
+
+        # Mock the confirm dialog to cancel
+        page.execute_script("window.confirm = function() { return false; }")
+
+        click_button 'Create Contest instance'
+
+        # Should create an inactive contest instance
+        expect(page).to have_content('Contest instance was successfully created')
+
+        created_instance = contest_description.contest_instances.last
+        expect(created_instance.active).to be false
+      end
+
+      it 'submits normally when active checkbox is already checked' do
+        visit new_container_contest_description_contest_instance_path(container, contest_description)
+
+        fill_in 'contest_instance_date_open', with: 1.week.from_now.strftime('%Y-%m-%dT%H:%M')
+        fill_in 'contest_instance_date_closed', with: 2.weeks.from_now.strftime('%Y-%m-%dT%H:%M')
+        check 'Active'
+
+        # Set up a spy to ensure confirm is not called
+        page.execute_script("window.confirmCalled = false; window.confirm = function() { window.confirmCalled = true; return true; }")
+
+        click_button 'Create Contest instance'
+
+        # Should create an active instance without confirmation
+        expect(page).to have_content('Contest instance was successfully created')
+
+        created_instance = contest_description.contest_instances.last
+        expect(created_instance.active).to be true
+
+        # Confirm should not have been called
+        confirm_called = page.execute_script("return window.confirmCalled")
+        expect(confirm_called).to be false
+      end
+    end
+
+    context 'when editing an existing contest instance' do
+      let!(:contest_instance) { create(:contest_instance, contest_description: contest_description, active: true) }
+
+      it 'does not show confirmation dialog when editing' do
+        visit edit_container_contest_description_contest_instance_path(container, contest_description, contest_instance)
+
+        uncheck 'Active'
+
+        # Set up a spy to ensure confirm is not called
+        page.execute_script("window.confirmCalled = false; window.confirm = function() { window.confirmCalled = true; return true; }")
+
+        click_button 'Update Contest instance'
+
+        # Should update without confirmation
+        expect(page).to have_content('Contest instance was successfully created/updated')
+
+        # Confirm should not have been called
+        confirm_called = page.execute_script("return window.confirmCalled")
+        expect(confirm_called).to be false
+
+        contest_instance.reload
+        expect(contest_instance.active).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Modified contest description factory to create active instances for testing.
- Enhanced contest instance creation specs to include category and class level associations.
- Improved system tests for contest activation workflow, ensuring proper handling of active checkbox and form submission logic.
- Updated JavaScript interactions to bypass confirmation dialogs for more streamlined testing.