### PR TITLE
Simple_tweaks

### DIFF
--- a/app/helpers/containers_helper.rb
+++ b/app/helpers/containers_helper.rb
@@ -16,7 +16,7 @@ module ContainersHelper
 
   def render_eligibility_rules(description)
     eligibility_plain = description.eligibility_rules.to_plain_text
-    if eligibility_plain.length > 100
+    if eligibility_plain.length > 60
       content_tag(:div) do
         truncate(eligibility_plain, length: 60, omission: '') +
         link_to(' ...more', '#',

--- a/app/views/containers/_entries_summary.html.erb
+++ b/app/views/containers/_entries_summary.html.erb
@@ -11,7 +11,7 @@
   <div>
     <div class="row">
       <div class="col-12">
-        <h5 class="mb-3">Total Entries in all Active Contests: <%= container.total_active_entries %></h5>
+        <h5 class="mb-3">Total Entries in all Active Instances of Active Contests: <%= container.total_active_entries %></h5>
 
         <% if container.entries_summary.any? %>
           <h6 class="mb-2">Entries by Campus:</h6>

--- a/spec/helpers/containers_helper_spec.rb
+++ b/spec/helpers/containers_helper_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe ContainersHelper, type: :helper do
   end
 
   describe "#render_eligibility_rules" do
-    context "when eligibility rules are longer than 100 characters" do
-      let(:long_text) { "These are very long eligibility rules that will definitely exceed the 100 character limit and therefore trigger the modal functionality." }
+    context "when eligibility rules are longer than 60 characters" do
+      let(:long_text) { "These are very long eligibility rules that will definitely exceed the 60 character limit and therefore trigger the modal functionality." }
       let(:rich_text) { instance_double(ActionText::RichText, to_plain_text: long_text) }
 
       before do
@@ -66,10 +66,10 @@ RSpec.describe ContainersHelper, type: :helper do
         expect(link['data-action']).to eq('click->modal#open')
         expect(link['data-modal-title']).to eq('Eligibility Rules')
         expect(link['href']).to eq('#')
-        expect(link.text).to eq('...more')
+        expect(link.text).to eq(' ...more')
 
         # Check truncated text
-        expect(parsed_result.text).to include(long_text[0..99])
+        expect(parsed_result.text).to include(long_text[0..59])
       end
     end
 


### PR DESCRIPTION
- Changed the header text in the entries summary partial to specify "Total Entries in all Active Instances of Active Contests," enhancing clarity and context for users.
- This update improves the user interface by providing a more accurate description of the displayed data.