### PR TITLE
Add preview for JudgingInstructionsMailer

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,7 @@
+class UsersController < ApplicationController
+  def lookup
+    query = params[:q].to_s.strip
+    users = User.where('first_name LIKE :q OR last_name LIKE :q OR email LIKE :q OR uid LIKE :q', q: "%#{query}%").limit(10)
+    render json: users.map { |u| { id: u.id, name: "#{u.first_name} #{u.last_name} (#{u.email})", uid: u.uid } }
+  end
+end

--- a/app/javascript/controllers/uid_lookup_controller.js
+++ b/app/javascript/controllers/uid_lookup_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["displayInput", "uidInput", "results"]
+  static values = { url: String }
 
   connect() {
     this.timeout = null
@@ -13,7 +14,8 @@ export default class extends Controller {
     this.timeout = setTimeout(() => {
       const query = this.displayInputTarget.value.trim()
       if (query.length > 0) {
-        fetch(`/containers/lookup_user?uid=${encodeURIComponent(query)}`)
+        const url = this.hasUrlValue ? this.urlValue : '/containers/lookup_user'
+        fetch(`${url}?${url.includes('lookup_user') ? 'uid' : 'q'}=${encodeURIComponent(query)}`)
           .then(response => response.json())
           .then(data => {
             this.showSuggestions(data)
@@ -28,11 +30,11 @@ export default class extends Controller {
     this.clearSuggestions()
     users.forEach(user => {
       const option = document.createElement('div')
-      option.textContent = user.display_name_and_uid
+      option.textContent = user.display_name_and_uid || user.name || `${user.first_name} ${user.last_name} (${user.email})`
       option.classList.add('suggestion')
       option.addEventListener('click', () => {
-        this.displayInputTarget.value = user.display_name_and_uid
-        this.uidInputTarget.value = user.uid
+        this.displayInputTarget.value = user.display_name_and_uid || user.name || `${user.first_name} ${user.last_name} (${user.email})`
+        this.uidInputTarget.value = user.uid || user.id
         this.clearSuggestions()
       })
       this.resultsTarget.appendChild(option)

--- a/app/mailers/judging_instructions_mailer.rb
+++ b/app/mailers/judging_instructions_mailer.rb
@@ -1,0 +1,32 @@
+class JudgingInstructionsMailer < ApplicationMailer
+  def send_instructions(round_judge_assignment)
+    @round_judge_assignment = round_judge_assignment
+    @judge = @round_judge_assignment.user
+    @judging_round = @round_judge_assignment.judging_round
+    @contest_instance = @judging_round.contest_instance
+    @contest_description = @contest_instance.contest_description
+    @container = @contest_description.container
+    @judge_email = @judge.normalize_email
+
+    # Get the special instructions from the judging round
+    @special_instructions = @judging_round.special_instructions.presence
+
+    # Get the contact email for display in the email body
+    # Use container's contact_email if present, otherwise use the default reply-to email
+    @contact_email = @container.contact_email.presence || 'LSA Evaluate Support <lsa-evaluate-support@umich.edu>'
+
+    subject = "Judging Instructions for #{@contest_description.name} - Round #{@judging_round.round_number}"
+
+    # Set mail options
+    mail_options = {
+      to: @judge_email,
+      subject: subject
+    }
+
+    # Override reply_to with container's contact_email if present
+    # If not present, the default reply-to from ApplicationMailer will be used
+    mail_options[:reply_to] = @container.contact_email if @container.contact_email.present?
+
+    mail(mail_options)
+  end
+end

--- a/app/mailers/results_mailer.rb
+++ b/app/mailers/results_mailer.rb
@@ -9,10 +9,7 @@ class ResultsMailer < ApplicationMailer
     @container = @contest_description.container
 
     # Get the contact email from the container, with fallbacks if not present
-    @contact_email = @container.contact_email.presence ||
-                    Rails.application.credentials.dig(:mailer, :default_contact_email) ||
-                    Rails.application.credentials.dig(:devise, :mailer_sender) ||
-                    'contests@example.com'
+    @contact_email = @container.contact_email.presence || 'LSA Evaluate Support <lsa-evaluate-support@umich.edu>'
 
     # Get all rankings for this entry in this round
     @rankings = EntryRanking.where(entry: @entry, judging_round: @round)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,6 +107,16 @@ class User < ApplicationRecord
     (display_name.presence || "#{first_name} #{last_name}")
   end
 
+  def normalize_email
+    if email.end_with?('@umich.edu') && email.include?('+')
+      local_part, _domain = email.split('@')
+      username, original_domain = local_part.split('+')
+      "#{username}@#{original_domain}"
+    else
+      email
+    end
+  end
+
   def display_initials_or_uid
     if display_name.present?
       display_name.split.map { |name| name[0].upcase }.join

--- a/app/views/containers/_assignment_form.html.erb
+++ b/app/views/containers/_assignment_form.html.erb
@@ -18,16 +18,18 @@
     </div>
   <% end %>
 
-  <div class="mb-3">
-    <%= f.label :uid_display, 'User' %>
-    <%= text_field_tag :uid_display, nil,
-      class: 'form-control',
-      data: {
-        uid_lookup_target: 'displayInput',
-        action: 'input->uid-lookup#lookup'
-      } %>
-    <%= f.hidden_field :uid, data: { uid_lookup_target: 'uidInput' } %>
-    <div data-uid-lookup-target="results" class="autocomplete-results"></div>
+  <div data-controller="uid-lookup" data-uid-lookup-url-value="<%= user_lookup_path %>">
+    <div class="mb-3">
+      <%= label_tag :uid_display, 'User' %>
+      <%= text_field_tag :uid_display, nil,
+        class: 'form-control',
+        data: {
+          uid_lookup_target: 'displayInput',
+          action: 'input->uid-lookup#lookup'
+        } %>
+      <%= hidden_field_tag 'assignment[uid]', nil, data: { uid_lookup_target: 'uidInput' } %>
+      <div data-uid-lookup-target="results" class="autocomplete-results"></div>
+    </div>
   </div>
 
   <div class="mb-3">
@@ -45,4 +47,3 @@
   <%= f.submit 'Add User', class: "btn btn-primary my-2" %>
   <%= link_to "Cancel", container_path(container), class: "text-danger link_to", data: { turbo: false, method: :get } %>
 <% end %>
-

--- a/app/views/contest_instances/_manage_judges.html.erb
+++ b/app/views/contest_instances/_manage_judges.html.erb
@@ -37,8 +37,10 @@
                     <em class="text-muted">No judges assigned to this round</em>
                   <% end %>
                 </div>
-                <div class="btn btn-sm btn-outline-success mb-1"><i class="bi bi-envelope me-1"></i>Send judging instructions
-                </div>
+                <% if round.judges.any? %>
+                  <div class="btn btn-sm btn-outline-success mb-1"><i class="bi bi-envelope me-1"></i>Send judging instructions
+                  </div>
+                <% end %>
             </div>
           </div>
 

--- a/app/views/contest_instances/_manage_judges.html.erb
+++ b/app/views/contest_instances/_manage_judges.html.erb
@@ -6,6 +6,18 @@
       <div class="card mb-3 border-<%= round.active ? 'success' : (round.completed ? 'secondary' : 'warning') %>">
         <div class="card-header d-flex justify-content-between align-items-center">
           <h5 class="mb-0">Round <%= round.round_number %></h5>
+          <% if round.judges.any? %>
+            <%= button_to send_instructions_container_contest_description_contest_instance_judging_round_path(
+                  @container, @contest_description, contest_instance, round
+                ),
+                method: :post,
+                class: "btn btn-sm btn-outline-success",
+                data: {
+                  turbo_confirm: "Send judging instructions to #{pluralize(round.judges.count, 'judge')}?"
+                } do %>
+              <i class="bi bi-envelope me-1"></i>Send judging instructions
+            <% end %>
+          <% end %>
           <span class="badge bg-<%= round.active ? 'success' : (round.completed ? 'secondary' : 'warning') %>">
             <%= round.active ? 'Active' : (round.completed ? 'Completed' : 'Pending') %>
           </span>
@@ -37,10 +49,6 @@
                     <em class="text-muted">No judges assigned to this round</em>
                   <% end %>
                 </div>
-                <% if round.judges.any? %>
-                  <div class="btn btn-sm btn-outline-success mb-1"><i class="bi bi-envelope me-1"></i>Send judging instructions
-                  </div>
-                <% end %>
             </div>
           </div>
 

--- a/app/views/contest_instances/_manage_judges.html.erb
+++ b/app/views/contest_instances/_manage_judges.html.erb
@@ -22,6 +22,7 @@
             <div class="col">
               <div class="d-flex align-items-center">
                 <strong class="me-3"><i class="bi bi-people me-1"></i> Judges Assigned:</strong>
+              </div>
                 <div class="d-flex flex-wrap">
                   <% if round.judges.any? %>
                     <% round.judges.each do |judge| %>
@@ -36,7 +37,8 @@
                     <em class="text-muted">No judges assigned to this round</em>
                   <% end %>
                 </div>
-              </div>
+                <div class="btn btn-sm btn-outline-success mb-1"><i class="bi bi-envelope me-1"></i>Send judging instructions
+                </div>
             </div>
           </div>
 

--- a/app/views/judging_assignments/_judging_pool.html.erb
+++ b/app/views/judging_assignments/_judging_pool.html.erb
@@ -36,14 +36,20 @@
     <div class="card-body">
       <p>Start typing the name or email address of a judge to search for them system-wide. If you don't find the judge you're looking for, you can create a new judge using the "Create a new judge ..." form below.</p>
       <%= form_with(model: [@container, @contest_description, @contest_instance, JudgingAssignment.new], local: true) do |f| %>
-        <div class="form-group">
-          <%= f.label :user_id, "Select Judge" %>
-          <%= f.select :user_id,
-              @available_judges.map { |u| ["#{u.first_name} #{u.last_name} (#{display_email(u.email)})", u.id] },
-              { prompt: "Select a judge" },
-              class: "form-control" %>
+        <div data-controller="uid-lookup">
+          <div class="mb-3">
+            <%= label_tag :uid_display, 'Judge' %>
+            <%= text_field_tag :uid_display, nil,
+              class: 'form-control',
+              data: {
+                uid_lookup_target: 'displayInput',
+                action: 'input->uid-lookup#lookup'
+              } %>
+            <%= hidden_field_tag 'judging_assignment[user_id]', nil, data: { uid_lookup_target: 'uidInput' } %>
+            <div data-uid-lookup-target="results" class="autocomplete-results"></div>
+          </div>
+          <%= f.submit "Assign Judge", class: "btn btn-primary mt-3" %>
         </div>
-        <%= f.submit "Assign Judge", class: "btn btn-primary mt-3" %>
       <% end %>
     </div>
   </div>

--- a/app/views/judging_assignments/_judging_pool.html.erb
+++ b/app/views/judging_assignments/_judging_pool.html.erb
@@ -36,7 +36,7 @@
     <div class="card-body">
       <p>Start typing the name or email address of a judge to search for them system-wide. If you don't find the judge you're looking for, you can create a new judge using the "Create a new judge ..." form below.</p>
       <%= form_with(model: [@container, @contest_description, @contest_instance, JudgingAssignment.new], local: true) do |f| %>
-        <div data-controller="uid-lookup">
+        <div data-controller="uid-lookup" data-uid-lookup-url-value="<%= judge_lookup_container_contest_description_contest_instance_judging_assignments_path(@container, @contest_description, @contest_instance) %>">
           <div class="mb-3">
             <%= label_tag :uid_display, 'Judge' %>
             <%= text_field_tag :uid_display, nil,
@@ -63,7 +63,7 @@
       </div>
       <div id="createJudgeCollapse" class="accordion-collapse collapse" aria-labelledby="createJudgeHeader" data-bs-parent="#createJudgeAccordion">
         <div class="accordion-body">
-          <p>Use this form to create a new judge and assign them to the pool of judges for this contest instance. The new judge will receive an email with instructions on how to log in to the judging dashboard.</p>
+          <p>Use this form to create a new judge and assign them to the pool of judges for this contest instance.</p>
           <%= form_with(url: create_judge_container_contest_description_contest_instance_judging_assignments_path(@container, @contest_description, @contest_instance), local: true, html: { novalidate: true }) do |f| %>
             <div class="form-group mb-3">
               <%= f.label :email, "Email Address" %>

--- a/app/views/judging_instructions_mailer/send_instructions.html.erb
+++ b/app/views/judging_instructions_mailer/send_instructions.html.erb
@@ -1,0 +1,87 @@
+<div style="max-width: 600px; margin: 0 auto; padding: 20px; font-family: Arial, sans-serif;">
+  <h1 style="color: #003366; font-size: 24px; margin-bottom: 20px;">
+    Judging Instructions for <%= @contest_description.name %>
+  </h1>
+
+  <p style="font-size: 16px; line-height: 1.6; color: #333;">
+    Dear <%= @judge.display_name_or_first_name_last_name %>,
+  </p>
+
+  <p style="font-size: 16px; line-height: 1.6; color: #333;">
+    You have been assigned as a judge for <strong>Round <%= @judging_round.round_number %></strong> of the <%= @contest_description.name %> contest.
+  </p>
+
+  <div style="background-color: #f0f7ff; padding: 15px; border-radius: 5px; margin: 20px 0;">
+    <h2 style="color: #003366; font-size: 18px; margin-bottom: 10px;">Judging Period</h2>
+    <p style="font-size: 16px; line-height: 1.6; color: #333; margin: 5px 0;">
+      <strong>Start Date:</strong> <%= I18n.l(@judging_round.start_date, format: :long) %><br>
+      <strong>End Date:</strong> <%= I18n.l(@judging_round.end_date, format: :long) %>
+    </p>
+  </div>
+
+  <% if @judging_round.required_entries_count > 0 %>
+    <div style="background-color: #fff5e6; padding: 15px; border-radius: 5px; margin: 20px 0;">
+      <h2 style="color: #003366; font-size: 18px; margin-bottom: 10px;">Requirements</h2>
+      <p style="font-size: 16px; line-height: 1.6; color: #333; margin: 5px 0;">
+        <strong>Minimum entries to evaluate:</strong> <%= @judging_round.required_entries_count %>
+      </p>
+      <% if @judging_round.require_internal_comments %>
+        <p style="font-size: 16px; line-height: 1.6; color: #333; margin: 5px 0;">
+          <strong>Internal comments:</strong> Required (minimum <%= @judging_round.min_internal_comment_words %> words)
+        </p>
+      <% end %>
+      <% if @judging_round.require_external_comments %>
+        <p style="font-size: 16px; line-height: 1.6; color: #333; margin: 5px 0;">
+          <strong>External comments:</strong> Required (minimum <%= @judging_round.min_external_comment_words %> words)<br>
+          <em style="font-size: 14px;">Note: External comments will be shared with applicants</em>
+        </p>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if @special_instructions.present? %>
+    <div style="background-color: #f9f9f9; padding: 20px; border-radius: 5px; margin: 20px 0; border: 1px solid #ddd;">
+      <h2 style="color: #003366; font-size: 18px; margin-bottom: 15px;">Special Instructions</h2>
+      <div style="font-size: 16px; line-height: 1.6; color: #333;">
+        <%= simple_format(@special_instructions) %>
+      </div>
+    </div>
+  <% end %>
+
+  <div style="background-color: #e6f3ff; padding: 15px; border-radius: 5px; margin: 20px 0; border: 1px solid #b3d9ff;">
+    <h3 style="color: #003366; font-size: 16px; margin-bottom: 10px;">Important: Email Account Access</h3>
+    <p style="font-size: 14px; line-height: 1.6; color: #333; margin: 5px 0;">
+      Only the email account <strong><%= @judge_email %></strong> has access to the judging system.
+    </p>
+    <p style="font-size: 14px; line-height: 1.6; color: #333; margin: 5px 0;">
+      If you need to use a different email account, please contact us to adjust your access.
+    </p>
+    <% unless @judge_email.end_with?('@umich.edu') %>
+      <p style="font-size: 14px; line-height: 1.6; color: #333; margin: 10px 0 5px 0;">
+        <strong>For non-@umich.edu accounts:</strong> You'll need to set up a Friend account at
+        <a href="https://friend.weblogin.umich.edu/friend/" style="color: #0066cc;">friend.weblogin.umich.edu</a>
+      </p>
+    <% end %>
+  </div>
+
+  <div style="text-align: center; margin: 30px 0;">
+    <%= link_to "Go to Judging Dashboard", judge_dashboard_index_url,
+        style: "display: inline-block; padding: 12px 30px; background-color: #00274C; color: white; text-decoration: none; border-radius: 5px; font-size: 16px;" %>
+  </div>
+
+  <p style="font-size: 16px; line-height: 1.6; color: #333;">
+    If you have any questions about the judging process, please contact us at
+    <a href="mailto:<%= @contact_email %>" style="color: #0066cc;"><%= @contact_email %></a>.
+  </p>
+
+  <p style="font-size: 16px; line-height: 1.6; color: #333;">
+    Thank you for your time and commitment to this contest.
+  </p>
+
+  <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
+
+  <p style="font-size: 14px; color: #666; text-align: center;">
+    This email was sent from LSA Evaluate.<br>
+    University of Michigan
+  </p>
+</div>

--- a/app/views/judging_instructions_mailer/send_instructions.text.erb
+++ b/app/views/judging_instructions_mailer/send_instructions.text.erb
@@ -1,0 +1,53 @@
+JUDGING INSTRUCTIONS FOR <%= @contest_description.name.upcase %>
+================================================================================
+
+Dear <%= @judge.display_name_or_first_name_last_name %>,
+
+You have been assigned as a judge for Round <%= @judging_round.round_number %> of the <%= @contest_description.name %> contest.
+
+JUDGING PERIOD
+--------------
+Start Date: <%= I18n.l(@judging_round.start_date, format: :long) %>
+End Date: <%= I18n.l(@judging_round.end_date, format: :long) %>
+
+<% if @judging_round.required_entries_count > 0 %>
+REQUIREMENTS
+------------
+Minimum entries to evaluate: <%= @judging_round.required_entries_count %>
+<% if @judging_round.require_internal_comments %>
+Internal comments: Required (minimum <%= @judging_round.min_internal_comment_words %> words)
+<% end %>
+<% if @judging_round.require_external_comments %>
+External comments: Required (minimum <%= @judging_round.min_external_comment_words %> words)
+Note: External comments will be shared with applicants
+<% end %>
+
+<% end %>
+<% if @special_instructions.present? %>
+SPECIAL INSTRUCTIONS
+-------------------
+<%= @special_instructions %>
+
+<% end %>
+TO ACCESS THE JUDGING DASHBOARD:
+-------------------------------
+Please visit: <%= judge_dashboard_index_url %>
+
+IMPORTANT: EMAIL ACCOUNT ACCESS
+-------------------------------
+Only the email account <%= @judge_email %> has access to the judging system.
+
+If you need to use a different email account, please contact us to adjust your access.
+<% unless @judge_email.end_with?('@umich.edu') %>
+
+For non-@umich.edu accounts: You'll need to set up a Friend account at
+https://friend.weblogin.umich.edu/friend/
+<% end %>
+
+If you have any questions about the judging process, please contact us at <%= @contact_email %>.
+
+Thank you for your time and commitment to this contest.
+
+--------------------------------------------------------------------------------
+This email was sent from LSA Evaluate.
+University of Michigan

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,6 +44,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
             patch :deactivate
             patch :complete
             patch :uncomplete
+            post :send_instructions
           end
           post 'update_rankings', on: :member
           post 'finalize_rankings', on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,22 @@ Rails.application.routes.draw do
 
   resources :users_dashboard, only: %i[ index show ]
 
+  # For generic user lookup (autocomplete for assignment form)
+  get 'users/lookup', to: 'users#lookup', as: :user_lookup
+
+  # For judge lookup (autocomplete for judging pool, nested under contest instance)
+  resources :containers do
+    resources :contest_descriptions do
+      resources :contest_instances do
+        resources :judging_assignments do
+          collection do
+            get :judge_lookup
+          end
+        end
+      end
+    end
+  end
+
   # Place this at the very end of the file to catch all undefined routes
   match '*path', to: 'errors#not_found', via: :all, constraints: lambda { |req|
     req.path.exclude?('/rails/active_storage') &&

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe UsersController, type: :controller do
+  describe '#lookup' do
+    let(:current_user) { create(:user) }
+    let!(:user1) { create(:user, first_name: 'Alice', last_name: 'Smith', email: 'alice@example.com', uid: 'alice1') }
+    let!(:user2) { create(:user, first_name: 'Bob', last_name: 'Jones', email: 'bob@example.com', uid: 'bobby') }
+    let!(:user3) { create(:user, first_name: 'Carol', last_name: 'Brown', email: 'carol@example.com', uid: 'carolb') }
+
+    before do
+      sign_in current_user
+    end
+
+    it 'returns users matching the query by name' do
+      get :lookup, params: { q: 'Alice' }, format: :json
+      results = JSON.parse(response.body)
+      expect(results).not_to be_empty
+      expect(results.first['name']).to include('Alice')
+    end
+
+    it 'returns users matching the query by email' do
+      get :lookup, params: { q: 'bob@example.com' }, format: :json
+      results = JSON.parse(response.body)
+      expect(results).not_to be_empty
+      expect(results.first['name']).to include('Bob')
+    end
+
+    it 'returns users matching the query by uid' do
+      get :lookup, params: { q: 'carolb' }, format: :json
+      results = JSON.parse(response.body)
+      expect(results).not_to be_empty
+      expect(results.first['name']).to include('Carol')
+    end
+
+    it 'returns JSON with id, name, and uid' do
+      get :lookup, params: { q: 'Alice' }, format: :json
+      results = JSON.parse(response.body)
+      expect(results).not_to be_empty
+      expect(results.first.keys).to include('id', 'name', 'uid')
+    end
+
+    it 'limits results to 10' do
+      create_list(:user, 15) do |user, i|
+        user.first_name = 'Test'
+        user.last_name = 'User'
+        user.email = "testuser#{i}@example.com"
+        user.uid = "testuser#{i}"
+        user.save!
+      end
+      get :lookup, params: { q: 'Test' }, format: :json
+      results = JSON.parse(response.body)
+      expect(results.length).to be <= 10
+    end
+  end
+end

--- a/spec/mailers/judging_instructions_mailer_spec.rb
+++ b/spec/mailers/judging_instructions_mailer_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+RSpec.describe JudgingInstructionsMailer, type: :mailer do
+  describe '#send_instructions' do
+    let(:container) { create(:container, contact_email: 'contest_admin@umich.edu') }
+    let(:contest_description) { create(:contest_description, :active, container: container, name: 'Test Contest') }
+    let(:contest_instance) { create(:contest_instance, contest_description: contest_description) }
+    let(:judging_round) do
+      create(:judging_round,
+             contest_instance: contest_instance,
+             round_number: 2,
+             special_instructions: 'Please evaluate entries based on creativity and originality.',
+             required_entries_count: 5,
+             require_internal_comments: true,
+             min_internal_comment_words: 50,
+             require_external_comments: true,
+             min_external_comment_words: 100)
+    end
+    let(:judge) { create(:user, :with_judge_role, email: 'judge@umich.edu', first_name: 'Jane', last_name: 'Doe') }
+    let(:round_judge_assignment) { create(:round_judge_assignment, :with_contest_assignment, user: judge, judging_round: judging_round) }
+
+    let(:mail) { described_class.send_instructions(round_judge_assignment) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq("Judging Instructions for Test Contest - Round 2")
+      expect(mail.to).to eq(['judge@umich.edu'])
+      expect(mail.from).to include(Rails.application.credentials.dig(:sendgrid, :mailer_sender))
+    end
+
+        it 'uses the container contact email as reply-to when present' do
+      expect(mail.reply_to).to eq([ 'contest_admin@umich.edu' ])
+    end
+
+    it 'falls back to default reply-to when container contact email is not present' do
+      # Create a new container without contact_email by overriding validation
+      container_without_email = container
+      container_without_email.contact_email = ''
+      container_without_email.save(validate: false)
+      contest_description.update!(container: container_without_email)
+
+      # Need to regenerate the mail with the updated container
+      mail_without_contact = described_class.send_instructions(round_judge_assignment)
+      # When no container email is set, it should use ApplicationMailer's default
+      expect(mail_without_contact.reply_to).to eq([ 'lsa-evaluate-support@umich.edu' ])
+    end
+
+    describe 'email body' do
+      it 'includes judge name' do
+        expect(mail.body.encoded).to include('Jane Doe')
+      end
+
+      it 'includes contest name and round number' do
+        expect(mail.body.encoded).to include('Test Contest')
+        expect(mail.body.encoded).to include('Round 2')
+      end
+
+      it 'includes judging period dates' do
+        expect(mail.body.encoded).to include(I18n.l(judging_round.start_date, format: :long))
+        expect(mail.body.encoded).to include(I18n.l(judging_round.end_date, format: :long))
+      end
+
+      it 'includes special instructions' do
+        expect(mail.body.encoded).to include('Please evaluate entries based on creativity and originality.')
+      end
+
+      it 'includes requirements' do
+        expect(mail.body.encoded).to include('5') # required_entries_count
+        expect(mail.body.encoded).to include('50') # min_internal_comment_words
+        expect(mail.body.encoded).to include('100') # min_external_comment_words
+      end
+
+      it 'includes link to judging dashboard' do
+        expect(mail.body.encoded).to include(judge_dashboard_index_url)
+      end
+
+      it 'includes contact email' do
+        expect(mail.body.encoded).to include('contest_admin@umich.edu')
+      end
+
+      it 'shows default contact email when container email is not present' do
+        container.contact_email = ''
+        container.save(validate: false)
+        contest_description.reload
+
+        mail_without_contact = described_class.send_instructions(round_judge_assignment)
+        expect(mail_without_contact.body.encoded).to include('lsa-evaluate-support@umich.edu')
+      end
+    end
+
+    context 'when special instructions are not present' do
+      before do
+        judging_round.update!(special_instructions: nil)
+      end
+
+      it 'does not include the special instructions section' do
+        # Check both parts of the multipart email
+        html_part = mail.html_part ? mail.html_part.body.to_s : mail.body.to_s
+        text_part = mail.text_part ? mail.text_part.body.to_s : mail.body.to_s
+
+        expect(html_part).not_to include('Special Instructions')
+        expect(text_part).not_to include('SPECIAL INSTRUCTIONS')
+      end
+    end
+
+    context 'when comment requirements are not present' do
+      before do
+        judging_round.update!(require_internal_comments: false, require_external_comments: false)
+      end
+
+      it 'does not include comment requirements' do
+        expect(mail.body.encoded).not_to include('Internal comments:')
+        expect(mail.body.encoded).not_to include('External comments:')
+      end
+    end
+  end
+end

--- a/spec/mailers/results_mailer_spec.rb
+++ b/spec/mailers/results_mailer_spec.rb
@@ -68,12 +68,12 @@ RSpec.describe ResultsMailer, type: :mailer do
       end
 
       it 'falls back to the default contact email from credentials' do
-        default_email = Rails.application.credentials.dig(:mailer, :default_contact_email)
+        default_email = 'LSA Evaluate Support <lsa-evaluate-support@umich.edu>'
 
         if default_email
           expect(mail.body.encoded).to include(default_email)
         else
-          default_sender = Rails.application.credentials.dig(:devise, :mailer_sender) || 'contests@example.com'
+          default_sender = Rails.application.credentials.dig(:devise, :mailer_sender)
           expect(mail.body.encoded).to include(default_sender)
         end
       end

--- a/test/mailers/previews/judging_instructions_mailer_preview.rb
+++ b/test/mailers/previews/judging_instructions_mailer_preview.rb
@@ -1,0 +1,125 @@
+class JudgingInstructionsMailerPreview < ActionMailer::Preview
+  def send_instructions
+    # Find or create sample data for preview
+    round_judge_assignment = RoundJudgeAssignment.joins(:user, :judging_round)
+                                                 .joins(user: :roles)
+                                                 .where(roles: { kind: 'Judge' })
+                                                 .first
+
+    if round_judge_assignment.nil?
+      # Create sample data if none exists
+      judge = User.joins(:roles).where(roles: { kind: 'Judge' }).first || create_sample_judge
+      judging_round = JudgingRound.includes(:contest_instance).first || create_sample_judging_round
+
+      round_judge_assignment = RoundJudgeAssignment.create!(
+        user: judge,
+        judging_round: judging_round
+      )
+    end
+
+    # Ensure the judging round has special instructions for preview
+    if round_judge_assignment.judging_round.special_instructions.blank?
+      round_judge_assignment.judging_round.update!(
+        special_instructions: sample_special_instructions
+      )
+    end
+
+    JudgingInstructionsMailer.send_instructions(round_judge_assignment)
+  end
+
+  private
+
+  def create_sample_judge
+    judge = User.create!(
+      email: "sample_judge@umich.edu",
+      first_name: "Sample",
+      last_name: "Judge",
+      uid: "sample_judge",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+
+    # Add judge role
+    judge_role = Role.find_or_create_by!(kind: 'Judge', description: 'Judge')
+    judge.roles << judge_role
+
+    judge
+  end
+
+  def create_sample_judging_round
+    contest_instance = ContestInstance.first || create_sample_contest_instance
+
+    JudgingRound.create!(
+      contest_instance: contest_instance,
+      round_number: 1,
+      start_date: 1.day.from_now,
+      end_date: 7.days.from_now,
+      required_entries_count: 5,
+      require_internal_comments: true,
+      min_internal_comment_words: 50,
+      require_external_comments: true,
+      min_external_comment_words: 100,
+      special_instructions: sample_special_instructions
+    )
+  end
+
+  def create_sample_contest_instance
+    contest_description = ContestDescription.first || create_sample_contest_description
+
+    ContestInstance.create!(
+      contest_description: contest_description,
+      date_open: 1.month.ago,
+      date_closed: 1.day.ago,
+      created_by: "admin@umich.edu",
+      active: true
+    )
+  end
+
+  def create_sample_contest_description
+    container = Container.first || create_sample_container
+
+    ContestDescription.create!(
+      name: "Sample Writing Contest",
+      container: container,
+      active: true
+    )
+  end
+
+  def create_sample_container
+    Container.create!(
+      name: "Sample Container",
+      contact_email: "contests@umich.edu"
+    )
+  end
+
+  def sample_special_instructions
+    <<~INSTRUCTIONS
+      Thank you for agreeing to judge this contest. Here are some important guidelines:
+
+      1. **Evaluation Criteria:**
+         - Originality and creativity (25%)
+         - Quality of writing and style (25%)
+         - Adherence to contest theme (25%)
+         - Overall impact and engagement (25%)
+
+      2. **Ranking Guidelines:**
+         - Please rank entries from 1 (best) to N (number of entries you review)
+         - Avoid giving the same rank to multiple entries
+         - Consider the target audience when evaluating
+
+      3. **Comment Requirements:**
+         - Internal comments are for contest administrators only
+         - External comments will be shared with contestants
+         - Please be constructive and encouraging in external comments
+
+      4. **Conflict of Interest:**
+         - If you recognize an entry or have any conflict of interest, please notify the contest administrator immediately
+
+      5. **Confidentiality:**
+         - Please do not discuss entries with other judges during the evaluation period
+         - All entries should be treated as confidential
+
+      If you have any questions, please don't hesitate to reach out to the contest administrator.
+    INSTRUCTIONS
+  end
+end


### PR DESCRIPTION
<message>Created a new preview class for the JudgingInstructionsMailer to facilitate the visualization of email content for the send_instructions method. This preview includes logic to generate sample data for judges and judging rounds, ensuring that the email displays accurate and relevant information. This addition enhances the development process by allowing for easier testing and verification of email formatting and content before sending.