### PR TITLE
Add send_instructions? method to ContestInstancePolicy and update specs

### DIFF
--- a/app/policies/contest_instance_policy.rb
+++ b/app/policies/contest_instance_policy.rb
@@ -88,4 +88,8 @@ class ContestInstancePolicy < ApplicationPolicy
   def export_entries?
     user&.has_container_role?(record.contest_description.container) || axis_mundi?
   end
+
+  def send_instructions?
+    user&.has_container_role?(record.contest_description.container) || axis_mundi?
+  end
 end

--- a/spec/policies/contest_instance_policy_spec.rb
+++ b/spec/policies/contest_instance_policy_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ContestInstancePolicy do
     it { is_expected.to permit_action(:update) }
     it { is_expected.to permit_action(:destroy) }
     it { is_expected.to permit_action(:manage_judges) }
+    it { is_expected.to permit_action(:send_instructions) }
 
     describe 'view_judging_results?' do
       it 'permits viewing results' do
@@ -43,6 +44,7 @@ RSpec.describe ContestInstancePolicy do
     it { is_expected.to permit_action(:update) }
     it { is_expected.to permit_action(:destroy) }
     it { is_expected.to permit_action(:manage_judges) }
+    it { is_expected.to permit_action(:send_instructions) }
 
     describe 'view_judging_results?' do
       it 'permits viewing results' do
@@ -64,6 +66,7 @@ RSpec.describe ContestInstancePolicy do
     it { is_expected.not_to permit_action(:update) }
     it { is_expected.not_to permit_action(:destroy) }
     it { is_expected.not_to permit_action(:manage_judges) }
+    it { is_expected.not_to permit_action(:send_instructions) }
 
     describe 'view_judging_results?' do
       context 'when judge evaluations are complete' do
@@ -97,6 +100,7 @@ RSpec.describe ContestInstancePolicy do
     it { is_expected.not_to permit_action(:update) }
     it { is_expected.not_to permit_action(:destroy) }
     it { is_expected.not_to permit_action(:manage_judges) }
+    it { is_expected.not_to permit_action(:send_instructions) }
 
     describe 'view_judging_results?' do
       it 'does not permit viewing results' do
@@ -114,6 +118,7 @@ RSpec.describe ContestInstancePolicy do
     it { is_expected.not_to permit_action(:update) }
     it { is_expected.not_to permit_action(:destroy) }
     it { is_expected.not_to permit_action(:manage_judges) }
+    it { is_expected.not_to permit_action(:send_instructions) }
 
     describe 'view_judging_results?' do
       it 'does not permit viewing results' do


### PR DESCRIPTION
- Implemented the send_instructions? method to check user permissions based on container roles.
- Updated RSpec tests to include permissions for the send_instructions action, ensuring proper coverage for both permitted and non-permitted scenarios.