### PR TITLE
Fix N+1, Bump minimatch, trix, dompurify, immutable, and undici dependencies

### DIFF
--- a/app/controllers/containers_controller.rb
+++ b/app/controllers/containers_controller.rb
@@ -17,8 +17,10 @@ class ContainersController < ApplicationController
       @container.assignments.container_managers
     ).includes(:user, :role)
     @assignment = @container.assignments.build
-    @container_contest_descriptions = @container.contest_descriptions.reorder('contest_descriptions.name ASC')
-    @active_contest_descriptions = @container.contest_descriptions.active.reorder('contest_descriptions.name ASC')
+    @container_contest_descriptions = @container.contest_descriptions
+                                                .includes(contest_instances: :entries)
+                                                .reorder('contest_descriptions.name ASC')
+    @active_contest_descriptions = @container_contest_descriptions.select(&:active?)
   end
 
   def new

--- a/app/helpers/contest_descriptions_helper.rb
+++ b/app/helpers/contest_descriptions_helper.rb
@@ -1,10 +1,9 @@
 module ContestDescriptionsHelper
   def contest_description_entries_link(description)
-    active_instances = description.contest_instances.where(active: true)
-    return nil if active_instances.empty?
+    first_active = description.contest_instances.detect(&:active?)
+    return nil unless first_active
 
-    first_active = active_instances.first
-    entry_count = first_active.entries.where(deleted: false).count
+    entry_count = first_active.entries.reject(&:deleted).size
     link_to("Active: #{pluralize(entry_count, 'entry')}",
             container_contest_description_contest_instance_path(description.container, description, first_active),
             class: 'btn btn-sm btn-primary small')
@@ -12,7 +11,7 @@ module ContestDescriptionsHelper
 
   def contest_description_summary(description)
     total_instances = description.contest_instances.count
-    active_instances = description.contest_instances.where(active: true)
+    active_instances = description.contest_instances.select(&:active?)
     summary = ''
     if active_instances.any?
       summary += contest_description_entries_link(description).to_s


### PR DESCRIPTION
This pull request improves how contest descriptions and their related data are loaded and displayed, focusing on optimizing database queries and making entry counts more accurate. The main changes involve eager loading related models to reduce N+1 queries, refining how active contest descriptions are selected, and improving the logic for counting entries.

**Performance and Query Optimization:**

* In `ContainersController#show`, contest descriptions are now eager-loaded with their `contest_instances` and associated `entries` to minimize N+1 query issues when displaying contest details.

**Logic Improvements:**

* The selection of active contest descriptions now uses Ruby's `select(&:active?)` on already loaded descriptions, ensuring only the relevant, active ones are processed.
* In `ContestDescriptionsHelper`, the method for finding the first active contest instance now uses `detect(&:active?)` for efficiency and clarity.
* Entry counts for active contest instances now use Ruby's `reject(&:deleted).size` instead of a database query, ensuring only non-deleted entries are counted and improving consistency with in-memory objects.
* The summary of contest descriptions now uses `select(&:active?)` rather than a database query, aligning with the eager-loaded data and reducing redundant queries.