### PR TITLE
Extend Rack::Defense to block common vulnerability scanner probes.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,49 +20,7 @@ require 'action_cable/engine'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-# Custom middleware to block PHP-related requests
-class Rack::Defense
-  def initialize(app)
-    @app = app
-  end
-
-  def call(env)
-    # Sanitize all string values in the Rack env to valid UTF-8 to prevent
-    # ArgumentError from invalid byte sequences in downstream middleware.
-    env.each do |key, value|
-      next unless value.is_a?(String)
-
-      env[key] = value.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
-    end
-
-    request = Rack::Request.new(env)
-
-    # Block requests with PHP/exe-related paths or content (all HTTP methods)
-    php_patterns = ['.php', '.exe', 'php-cgi', 'xampp', 'wp-admin', 'wp-login']
-    if php_patterns.any? { |p| request.path.include?(p) || request.query_string.include?(p) } ||
-       (request.post? && (request.content_type.to_s.include?('php') || request.body.read.to_s.include?('php')))
-      return [403, { 'Content-Type' => 'text/plain' }, ['Forbidden']]
-    end
-
-    # Block requests with suspicious headers
-    if request.env['HTTP_USER_AGENT'].to_s.include?('Custom-AsyncHttpClient') ||
-       request.env['HTTP_X_REQUEST_ID'].to_s.include?('cve_2024_4577')
-      return [403, { 'Content-Type' => 'text/plain' }, ['Forbidden']]
-    end
-
-    # Block known malicious IPs
-    suspicious_ips = ['91.99.22.81'] # Add more IPs as needed
-    if suspicious_ips.include?(request.ip)
-      return [403, { 'Content-Type' => 'text/plain' }, ['Forbidden']]
-    end
-
-    @app.call(env)
-  rescue ArgumentError => e
-    raise unless e.message.include?('invalid byte sequence')
-
-    [400, { 'Content-Type' => 'text/plain' }, ['Bad Request']]
-  end
-end
+require_relative '../lib/rack/defense'
 
 module LsaEvaluate
   class Application < Rails::Application # rubocop:disable Style/Documentation

--- a/lib/rack/defense.rb
+++ b/lib/rack/defense.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'stringio'
-
 module Rack
   # Early-request filter for automated vulnerability scans and exploit probes.
   # This Rails app does not serve PHP, ASP, CGI, or other foreign stack assets.
@@ -34,11 +32,10 @@ module Rack
     def call(env)
       sanitize_env!(env)
 
-      return forbidden if probe_post_body?(env)
-
       request = Rack::Request.new(env)
 
       return forbidden if probe_path_request?(request)
+      return forbidden if probe_post_body?(request)
       return forbidden if SUSPICIOUS_HEADER_CHECKS.any? { |check| check.call(env) }
       return forbidden if SUSPICIOUS_IPS.include?(request.ip)
 
@@ -68,17 +65,16 @@ module Rack
         PROBE_PATH_PATTERNS.any? { |pattern| path.include?(pattern.downcase) || query.include?(pattern.downcase) }
     end
 
-    def probe_post_body?(env)
-      return false unless env['REQUEST_METHOD'] == 'POST'
+    def probe_post_body?(request)
+      return false unless request.post?
 
-      content_type = env['CONTENT_TYPE'].to_s.downcase
-      return true if content_type.include?('php')
+      return true if request.content_type.to_s.downcase.include?('php')
 
-      input = env['rack.input']
-      return false unless input.respond_to?(:read)
+      body = request.body
+      return false unless body.respond_to?(:read)
 
-      content = input.read
-      env['rack.input'] = StringIO.new(content)
+      content = body.read
+      body.rewind if body.respond_to?(:rewind)
       content.downcase.include?('php')
     end
 

--- a/lib/rack/defense.rb
+++ b/lib/rack/defense.rb
@@ -32,9 +32,11 @@ module Rack
     def call(env)
       sanitize_env!(env)
 
+      return forbidden if probe_post_body?(env)
+
       request = Rack::Request.new(env)
 
-      return forbidden if probe_request?(request)
+      return forbidden if probe_path_request?(request)
       return forbidden if SUSPICIOUS_HEADER_CHECKS.any? { |check| check.call(env) }
       return forbidden if SUSPICIOUS_IPS.include?(request.ip)
 
@@ -55,11 +57,8 @@ module Rack
       end
     end
 
-    def probe_request?(request)
-      path = request.path.downcase
-      query = request.query_string.downcase
-
-      probe_path?(path, query) || probe_post_body?(request)
+    def probe_path_request?(request)
+      probe_path?(request.path.downcase, request.query_string.downcase)
     end
 
     def probe_path?(path, query)
@@ -67,10 +66,15 @@ module Rack
         PROBE_PATH_PATTERNS.any? { |pattern| path.include?(pattern.downcase) || query.include?(pattern.downcase) }
     end
 
-    def probe_post_body?(request)
-      return false unless request.post?
+    def probe_post_body?(env)
+      return false unless env['REQUEST_METHOD'] == 'POST'
+      return true if env['CONTENT_TYPE'].to_s.include?('php')
 
-      request.content_type.to_s.include?('php') || request.body.read.to_s.include?('php')
+      input = env['rack.input']
+      content = input.read
+      input.rewind if input.respond_to?(:rewind)
+
+      content.include?('php')
     end
 
     def forbidden

--- a/lib/rack/defense.rb
+++ b/lib/rack/defense.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'stringio'
+
 module Rack
   # Early-request filter for automated vulnerability scans and exploit probes.
   # This Rails app does not serve PHP, ASP, CGI, or other foreign stack assets.
@@ -68,13 +70,16 @@ module Rack
 
     def probe_post_body?(env)
       return false unless env['REQUEST_METHOD'] == 'POST'
-      return true if env['CONTENT_TYPE'].to_s.include?('php')
+
+      content_type = env['CONTENT_TYPE'].to_s.downcase
+      return true if content_type.include?('php')
 
       input = env['rack.input']
-      content = input.read
-      input.rewind if input.respond_to?(:rewind)
+      return false unless input.respond_to?(:read)
 
-      content.include?('php')
+      content = input.read
+      env['rack.input'] = StringIO.new(content)
+      content.downcase.include?('php')
     end
 
     def forbidden

--- a/lib/rack/defense.rb
+++ b/lib/rack/defense.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Rack
+  # Early-request filter for automated vulnerability scans and exploit probes.
+  # This Rails app does not serve PHP, ASP, CGI, or other foreign stack assets.
+  class Defense
+    # File extensions used by scanners probing non-Rails stacks.
+    PROBE_EXTENSIONS = %w[
+      .php .exe .cgi .shtml .aspx .cfm .jsa .jsp .asp .pl
+      .asmx .ashx .dll .bat .config
+    ].freeze
+
+    # Substrings matched against the request path or query string.
+    PROBE_PATH_PATTERNS = [
+      'php-cgi', 'xampp', 'wp-admin', 'wp-login',
+      'officescan', 'kubepi', 'administrator/manifests',
+      'ext-js', 'WebApp/', 'eonweb', 'phoenix/favicon',
+      '/CHANGELOG.txt', '/images/logo'
+    ].freeze
+
+    SUSPICIOUS_HEADER_CHECKS = [
+      ->(env) { env['HTTP_USER_AGENT'].to_s.include?('Custom-AsyncHttpClient') },
+      ->(env) { env['HTTP_X_REQUEST_ID'].to_s.include?('cve_2024_4577') }
+    ].freeze
+
+    SUSPICIOUS_IPS = ['91.99.22.81'].freeze
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      sanitize_env!(env)
+
+      request = Rack::Request.new(env)
+
+      return forbidden if probe_request?(request)
+      return forbidden if SUSPICIOUS_HEADER_CHECKS.any? { |check| check.call(env) }
+      return forbidden if SUSPICIOUS_IPS.include?(request.ip)
+
+      @app.call(env)
+    rescue ArgumentError => e
+      raise unless e.message.include?('invalid byte sequence')
+
+      [400, { 'Content-Type' => 'text/plain' }, ['Bad Request']]
+    end
+
+    private
+
+    def sanitize_env!(env)
+      env.each do |key, value|
+        next unless value.is_a?(String)
+
+        env[key] = value.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
+      end
+    end
+
+    def probe_request?(request)
+      path = request.path.downcase
+      query = request.query_string.downcase
+
+      probe_path?(path, query) || probe_post_body?(request)
+    end
+
+    def probe_path?(path, query)
+      PROBE_EXTENSIONS.any? { |ext| path.include?(ext) || query.include?(ext) } ||
+        PROBE_PATH_PATTERNS.any? { |pattern| path.include?(pattern.downcase) || query.include?(pattern.downcase) }
+    end
+
+    def probe_post_body?(request)
+      return false unless request.post?
+
+      request.content_type.to_s.include?('php') || request.body.read.to_s.include?('php')
+    end
+
+    def forbidden
+      [403, { 'Content-Type' => 'text/plain' }, ['Forbidden']]
+    end
+  end
+end

--- a/spec/middleware/rack_defense_spec.rb
+++ b/spec/middleware/rack_defense_spec.rb
@@ -71,22 +71,42 @@ RSpec.describe Rack::Defense do
 
     it 'preserves the POST body for downstream handlers' do
       captured_body = nil
+      original_input = nil
       inspecting_app = lambda do |env|
         captured_body = env['rack.input'].read
         [200, {}, ['OK']]
       end
 
-      status, = described_class.new(inspecting_app).call(
-        Rack::MockRequest.env_for(
-          '/entries',
-          method: 'POST',
-          input: 'name=test&value=1',
-          'CONTENT_TYPE' => 'application/x-www-form-urlencoded'
-        )
+      env = Rack::MockRequest.env_for(
+        '/entries',
+        method: 'POST',
+        input: 'name=test&value=1',
+        'CONTENT_TYPE' => 'application/x-www-form-urlencoded'
       )
+      original_input = env['rack.input']
+
+      status, = described_class.new(inspecting_app).call(env)
 
       expect(status).to eq(200)
       expect(captured_body).to eq('name=test&value=1')
+      expect(env['rack.input']).to equal(original_input)
+    end
+
+    it 'does not desync Rack POST cache from rack.input' do
+      inspecting_app = ->(_env) { [200, {}, ['OK']] }
+      env = Rack::MockRequest.env_for(
+        '/entries',
+        method: 'POST',
+        input: 'name=test&value=1',
+        'CONTENT_TYPE' => 'application/x-www-form-urlencoded'
+      )
+
+      status, = described_class.new(inspecting_app).call(env)
+
+      expect(status).to eq(200)
+      request = Rack::Request.new(env)
+      expect(request.POST).to eq('name' => 'test', 'value' => '1')
+      expect(env[Rack::RACK_REQUEST_FORM_INPUT]).to equal(env['rack.input'])
     end
   end
 

--- a/spec/middleware/rack_defense_spec.rb
+++ b/spec/middleware/rack_defense_spec.rb
@@ -50,6 +50,26 @@ RSpec.describe Rack::Defense do
 
       expect(status).to eq(403)
     end
+
+    it 'preserves the POST body for downstream handlers' do
+      captured_body = nil
+      inspecting_app = lambda do |env|
+        captured_body = env['rack.input'].read
+        [200, {}, ['OK']]
+      end
+
+      status, = described_class.new(inspecting_app).call(
+        Rack::MockRequest.env_for(
+          '/entries',
+          method: 'POST',
+          input: 'name=test&value=1',
+          'CONTENT_TYPE' => 'application/x-www-form-urlencoded'
+        )
+      )
+
+      expect(status).to eq(200)
+      expect(captured_body).to eq('name=test&value=1')
+    end
   end
 
   describe 'invalid UTF-8 handling' do

--- a/spec/middleware/rack_defense_spec.rb
+++ b/spec/middleware/rack_defense_spec.rb
@@ -13,18 +13,31 @@ RSpec.describe Rack::Defense do
     middleware.call(env)
   end
 
-  describe 'PHP / probe path blocking' do
-    it 'blocks GET requests to php-cgi probe paths' do
-      status, _headers, body = call_with(path: '/xampp/php-cgi.exe')
+  describe 'probe path blocking' do
+    [
+      '/xampp/php-cgi.exe',
+      '/php-cgi/php-cgi.exe',
+      '/home.cgi',
+      '/start.shtml',
+      '/login.aspx',
+      '/main.cfm',
+      '/menu.jsa',
+      '/kubepi/fav.png',
+      '/officescan/console/html/localization.js',
+      '/administrator/manifests/files/joomla.xml',
+      '/WebApp/js/UI_String.js',
+      '/ext-js/app/common/zld_product_spec.js',
+      '/css/eonweb.css',
+      '/images/logo.gif',
+      '/phoenix/favicon.ico',
+      '/CHANGELOG.txt'
+    ].each do |probe_path|
+      it "blocks GET requests to #{probe_path}" do
+        status, _headers, body = call_with(path: probe_path)
 
-      expect(status).to eq(403)
-      expect(body).to eq(['Forbidden'])
-    end
-
-    it 'blocks GET requests to /php-cgi/php-cgi.exe' do
-      status, = call_with(path: '/php-cgi/php-cgi.exe')
-
-      expect(status).to eq(403)
+        expect(status).to eq(403)
+        expect(body).to eq(['Forbidden'])
+      end
     end
 
     it 'blocks POST requests with php content in the body' do

--- a/spec/middleware/rack_defense_spec.rb
+++ b/spec/middleware/rack_defense_spec.rb
@@ -51,6 +51,24 @@ RSpec.describe Rack::Defense do
       expect(status).to eq(403)
     end
 
+    it 'blocks POST requests with uppercase PHP tags in the body' do
+      status, = call_with(
+        path: '/',
+        method: 'POST',
+        headers: { 'CONTENT_TYPE' => 'application/x-www-form-urlencoded' },
+        input: 'payload=<?PHP system($_GET["cmd"]); ?>'
+      )
+
+      expect(status).to eq(403)
+    end
+
+    it 'does not raise when rack.input is missing' do
+      env = Rack::MockRequest.env_for('/', method: 'POST')
+      env.delete('rack.input')
+
+      expect { middleware.call(env) }.not_to raise_error
+    end
+
     it 'preserves the POST body for downstream handlers' do
       captured_body = nil
       inspecting_app = lambda do |env|


### PR DESCRIPTION
Move middleware into lib/rack/defense.rb and add foreign-stack extensions plus known probe path patterns seen in staging logs.