### PR TITLE
Enhance SAML authentication and preserve contest invite paths

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,11 +25,11 @@ class ApplicationController < ActionController::Base
   protected
 
   def after_sign_in_path_for(resource)
-    if resource.judge?
-      judge_dashboard_path
-    else
-      root_path
-    end
+    stored_location_for(resource) || default_sign_in_path_for(resource)
+  end
+
+  def default_sign_in_path_for(resource)
+    resource.judge? ? judge_dashboard_path : root_path
   end
 
   def after_sign_out_path_for(resource_or_scope)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,11 +25,42 @@ class ApplicationController < ActionController::Base
   protected
 
   def after_sign_in_path_for(resource)
-    stored_location_for(resource) || default_sign_in_path_for(resource)
+    # SAML POSTs from the IdP often arrive without the Rails session cookie
+    # (SameSite). Prefer RelayState / omniauth.origin, which survive that round-trip.
+    saml_preserved_return_path ||
+      safe_internal_redirect_path(stored_location_for(resource)) ||
+      default_sign_in_path_for(resource)
   end
 
   def default_sign_in_path_for(resource)
     resource.judge? ? judge_dashboard_path : root_path
+  end
+
+  def saml_preserved_return_path
+    safe_internal_redirect_path(request.params['RelayState']) ||
+      safe_internal_redirect_path(request.env['omniauth.origin'])
+  end
+
+  def safe_internal_redirect_path(path)
+    return if path.blank?
+
+    uri = URI.parse(path)
+    if uri.host.present?
+      return unless uri.host == request.host
+
+      path = [ uri.path, uri.query ].compact.join('?')
+    end
+
+    return unless path.start_with?('/') && !path.start_with?('//')
+
+    # Homepage / login origins are not meaningful return destinations; fall
+    # through to role-based defaults (e.g. judges → judge dashboard).
+    path_only = path.split('?', 2).first
+    return if path_only.blank? || path_only == '/' || path_only == root_path
+
+    path
+  rescue URI::InvalidURIError
+    nil
   end
 
   def after_sign_out_path_for(resource_or_scope)

--- a/app/controllers/concerns/contest_invite_session.rb
+++ b/app/controllers/concerns/contest_invite_session.rb
@@ -4,6 +4,7 @@ module ContestInviteSession
   extend ActiveSupport::Concern
 
   REDEEMED_SESSION_KEY = :redeemed_contest_instances
+  PENDING_SESSION_KEY = :pending_contest_invite_token
 
   included do
     before_action :load_redeemed_contest_instances_into_current
@@ -19,6 +20,14 @@ module ContestInviteSession
     session[REDEEMED_SESSION_KEY] ||= {}
     session[REDEEMED_SESSION_KEY][contest_instance.id.to_s] = contest_instance.access_token
     Current.redeemed_contest_instances = session[REDEEMED_SESSION_KEY]
+  end
+
+  def remember_pending_contest_invite!(contest_instance)
+    session[PENDING_SESSION_KEY] = contest_instance.access_token
+  end
+
+  def consume_pending_contest_invite_token
+    session.delete(PENDING_SESSION_KEY)
   end
 
   def redeemed_token_for(contest_instance)

--- a/app/controllers/contest_invites_controller.rb
+++ b/app/controllers/contest_invites_controller.rb
@@ -4,13 +4,14 @@ class ContestInvitesController < ApplicationController
   def show
     @contest_instance = ContestInstance.find_by!(access_token: params[:token])
 
-    unless current_user.profile
-      redirect_to new_profile_path, alert: 'Please create your profile before accessing this contest.'
+    if @contest_instance.private_visibility? && @contest_instance.invite_list? && !@contest_instance.invited?(current_user)
+      redirect_to applicant_dashboard_path, alert: 'You are not invited to submit to this contest.'
       return
     end
 
-    if @contest_instance.private_visibility? && @contest_instance.invite_list? && !@contest_instance.invited?(current_user)
-      redirect_to applicant_dashboard_path, alert: 'You are not invited to submit to this contest.'
+    unless current_user.profile
+      remember_pending_contest_invite!(@contest_instance)
+      redirect_to new_profile_path, alert: 'Please create your profile before accessing this contest.'
       return
     end
 

--- a/app/controllers/contest_invites_controller.rb
+++ b/app/controllers/contest_invites_controller.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 class ContestInvitesController < ApplicationController
+  skip_before_action :authenticate_user!, only: :show
+
   def show
     @contest_instance = ContestInstance.find_by!(access_token: params[:token])
+
+    unless user_signed_in?
+      store_location_for(:user, contest_invite_path(token: params[:token]))
+      redirect_to root_path, alert: 'Please log in to access this contest.'
+      return
+    end
 
     if @contest_instance.private_visibility? && @contest_instance.invite_list? && !@contest_instance.invited?(current_user)
       redirect_to applicant_dashboard_path, alert: 'You are not invited to submit to this contest.'
@@ -31,6 +39,7 @@ class ContestInvitesController < ApplicationController
     redirect_to new_entry_path(contest_instance_id: @contest_instance.id),
                 notice: "Welcome to #{@contest_instance.contest_description.name}."
   rescue ActiveRecord::RecordNotFound
-    redirect_to applicant_dashboard_path, alert: 'Invalid or expired contest invite link.'
+    redirect_to user_signed_in? ? applicant_dashboard_path : root_path,
+                alert: 'Invalid or expired contest invite link.'
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -41,7 +41,7 @@ class ProfilesController < ApplicationController
 
     respond_to do |format|
       if @profile.save
-        format.html { redirect_to applicant_dashboard_path, notice: 'Profile was successfully created.' }
+        format.html { redirect_to profile_created_redirect_path, notice: 'Profile was successfully created.' }
       else
         format.html { render :new, status: :unprocessable_entity }
       end
@@ -78,6 +78,12 @@ class ProfilesController < ApplicationController
   def authorize_profile
     authorize @profile
   end
+
+  def profile_created_redirect_path
+    token = consume_pending_contest_invite_token
+    token.present? ? contest_invite_path(token: token) : applicant_dashboard_path
+  end
+
   # Only allow a list of trusted parameters through.
   def profile_params
     params.require(:profile).permit(:user_id, :umid, :preferred_first_name, :preferred_last_name, :class_level_id, :school_id, :campus_id,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,6 +30,12 @@ module ApplicationHelper
     redirect_to(session.delete(:return_to) || default, anchor: 'top')
   end
 
+  # Origin passed to SAML so RelayState can restore private-contest (and other) deep links.
+  def saml_authorize_params
+    origin = session['user_return_to'].presence
+    origin ? { origin: origin } : {}
+  end
+
   def boolean_to_yes_no(value)
     if value
       content_tag(:span, 'Yes', class: 'text-success fw-bold')

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,6 +1,9 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with U-M account", omniauth_authorize_path(resource_name, provider), class: "btn btn-warning btn-sm mb-4", data: { turbo: false } %><br />
+    <%= button_to "Sign in with U-M account", omniauth_authorize_path(resource_name, provider),
+                  params: saml_authorize_params,
+                  class: "btn btn-warning btn-sm mb-4",
+                  data: { turbo: false } %><br />
   <% end %>
 <% end %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -29,7 +29,10 @@
           <% end %>
         </div>
         <div class="d-grid w-25 ms-6 mt-6 mb-8">
-          <%= button_to "Login to LSA Evaluate", user_saml_omniauth_authorize_path, class: "btn btn-warning btn-sm mb-4", data: { turbo: "false" } %>
+          <%= button_to "Login to LSA Evaluate", user_saml_omniauth_authorize_path,
+                        params: saml_authorize_params,
+                        class: "btn btn-warning btn-sm mb-4",
+                        data: { turbo: "false" } %>
         </div>
       </div>
     </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -308,6 +308,9 @@ Devise.setup do |config|
                                           person_affiliation: [ 'urn:oid:1.3.6.1.4.1.5923.1.1.1.1' ],
                                           principal_name: [ 'urn:oid:1.3.6.1.4.1.5923.1.1.1.6' ] },
                   request_attributes: {},
+                  # Carry post-login destination through the IdP via SAML RelayState.
+                  # Session-based Devise return paths are often lost on the ACS POST.
+                  idp_sso_service_url_runtime_params: { origin: :RelayState },
                   idp_cert_fingerprint: idp_fingerprint,
                   idp_cert_fingerprint_algorithm: 'http://www.w3.org/2000/09/xmldsig#sha256',
                   allowed_clock_drift: 10,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    def index
+      head :ok
+    end
+  end
+
+  describe '#after_sign_in_path_for' do
+    let(:judge) { create(:user, :with_judge_role) }
+
+    it 'uses the stored destination before the role-based default' do
+      session['user_return_to'] = '/c/private-contest-token'
+
+      expect(controller.send(:after_sign_in_path_for, judge)).to eq('/c/private-contest-token')
+    end
+
+    it 'uses the role-based default without a stored destination' do
+      expect(controller.send(:after_sign_in_path_for, judge)).to eq(judge_dashboard_path)
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,10 +12,41 @@ RSpec.describe ApplicationController, type: :controller do
   describe '#after_sign_in_path_for' do
     let(:judge) { create(:user, :with_judge_role) }
 
+    it 'uses SAML RelayState before the role-based default' do
+      allow(controller.request).to receive(:params).and_return(
+        ActionController::Parameters.new('RelayState' => '/c/private-contest-token')
+      )
+
+      expect(controller.send(:after_sign_in_path_for, judge)).to eq('/c/private-contest-token')
+    end
+
+    it 'uses omniauth.origin when RelayState is absent' do
+      request.env['omniauth.origin'] = '/c/from-omniauth-origin'
+
+      expect(controller.send(:after_sign_in_path_for, judge)).to eq('/c/from-omniauth-origin')
+    end
+
     it 'uses the stored destination before the role-based default' do
       session['user_return_to'] = '/c/private-contest-token'
 
       expect(controller.send(:after_sign_in_path_for, judge)).to eq('/c/private-contest-token')
+    end
+
+    it 'rejects external RelayState values' do
+      allow(controller.request).to receive(:params).and_return(
+        ActionController::Parameters.new('RelayState' => 'https://evil.example/phish')
+      )
+
+      expect(controller.send(:after_sign_in_path_for, judge)).to eq(judge_dashboard_path)
+    end
+
+    it 'ignores homepage RelayState so judges still land on the dashboard' do
+      allow(controller.request).to receive(:params).and_return(
+        ActionController::Parameters.new('RelayState' => '/')
+      )
+      request.env['omniauth.origin'] = '/'
+
+      expect(controller.send(:after_sign_in_path_for, judge)).to eq(judge_dashboard_path)
     end
 
     it 'uses the role-based default without a stored destination' do

--- a/spec/controllers/contest_invites_controller_spec.rb
+++ b/spec/controllers/contest_invites_controller_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe ContestInvitesController, type: :controller do
         get :show, params: { token: contest_instance.access_token }
 
         expect(response).to redirect_to(new_profile_path)
+        expect(session[:pending_contest_invite_token]).to eq(contest_instance.access_token)
       end
     end
   end

--- a/spec/controllers/contest_invites_controller_spec.rb
+++ b/spec/controllers/contest_invites_controller_spec.rb
@@ -64,6 +64,20 @@ RSpec.describe ContestInvitesController, type: :controller do
       end
     end
 
+    context 'when the user is not signed in' do
+      let(:contest_instance) { create(:contest_instance) }
+
+      before { sign_out user }
+
+      it 'stores the invite path and redirects to login' do
+        get :show, params: { token: contest_instance.access_token }
+
+        expect(response).to redirect_to(root_path)
+        expect(session['user_return_to']).to eq(contest_invite_path(token: contest_instance.access_token))
+        expect(flash[:alert]).to match(/log in/i)
+      end
+    end
+
     context 'when the user has no profile' do
       let(:user_without_profile) { create(:user) }
       let(:contest_instance) { create(:contest_instance) }

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProfilesController, type: :controller do
+  let(:user) { create(:user) }
+  let(:contest_instance) { create(:contest_instance) }
+  let(:profile_attributes) do
+    attributes_for(:profile).merge(
+      class_level_id: create(:class_level).id,
+      school_id: create(:school).id,
+      campus_id: create(:campus).id
+    )
+  end
+
+  before { sign_in user }
+
+  describe 'POST #create' do
+    it 'returns to a pending contest invite after creating the profile' do
+      session[:pending_contest_invite_token] = contest_instance.access_token
+
+      post :create, params: { profile: profile_attributes }
+
+      expect(response).to redirect_to(contest_invite_path(token: contest_instance.access_token))
+      expect(session[:pending_contest_invite_token]).to be_nil
+    end
+
+    it 'uses the applicant dashboard when there is no pending invite' do
+      post :create, params: { profile: profile_attributes }
+
+      expect(response).to redirect_to(applicant_dashboard_path)
+    end
+  end
+end


### PR DESCRIPTION
This pull request enhances the authentication and contest invitation flow, especially for users accessing private contest links via SAML login. It ensures users are redirected to the correct destination after authentication, even when session data is lost during SAML round-trips. It also improves the handling of pending contest invites for users who must create a profile before accessing a contest. Comprehensive tests are added to verify these scenarios.

**Authentication and SAML login improvements:**
* Updated `after_sign_in_path_for` in `ApplicationController` to prefer SAML `RelayState` and `omniauth.origin` for post-login redirection, ensuring deep links (like private contest invites) are preserved through SAML authentication. Added robust path validation to prevent open redirects.
* Passed the intended post-login destination as SAML `RelayState` by updating the SAML button helpers and Devise configuration (`idp_sso_service_url_runtime_params`). [[1]](diffhunk://#diff-5f3fc5e3977d242572aa1d08551f5eb557de0ccaff30370838ee9df5386ea0daR33-R38) [[2]](diffhunk://#diff-cbfc8fbcf7e390b1a2f4cc4b8f24c59023e6a3abdafaef2d55c7a9edb053c026L4-R7) [[3]](diffhunk://#diff-6a8ea69ca566afd1812ab9732d330b9de4659d8c5163a8c4c5c6945177a13a9cL32-R35) [[4]](diffhunk://#diff-cb6e8126296dbc007e7625eee863de5c3213ed949b9999ea3418775f65826531R311-R313)

**Contest invite and profile creation flow:**
* Modified `ContestInvitesController` to redirect unauthenticated users to login and store the intended invite path for redirect after authentication. For users without profiles, the contest invite token is saved in the session and used to return the user to the invite after profile creation. [[1]](diffhunk://#diff-bf0cb270dee71a8df16895dffb1a12d8d642cbaff1f3ab9a917526015b79b91cR4-R11) [[2]](diffhunk://#diff-bf0cb270dee71a8df16895dffb1a12d8d642cbaff1f3ab9a917526015b79b91cR20-R25) [[3]](diffhunk://#diff-29ac4a689471ba16f783531c8b0a4fb5e82572e8d8e4aee453c0bd8258e56379R7) [[4]](diffhunk://#diff-29ac4a689471ba16f783531c8b0a4fb5e82572e8d8e4aee453c0bd8258e56379R25-R32) [[5]](diffhunk://#diff-7a47d335107fc35c2e79cc9c2b0a195c863594dd2343bcd48a4c770ac4af673cL44-R44) [[6]](diffhunk://#diff-7a47d335107fc35c2e79cc9c2b0a195c863594dd2343bcd48a4c770ac4af673cR81-R86)
* Improved error handling for invalid or expired contest invite links, redirecting users appropriately based on authentication state.

**Testing and validation:**
* Added comprehensive controller specs for the new redirection logic in `ApplicationController`, `ContestInvitesController`, and `ProfilesController`, covering SAML RelayState, pending contest invites, and security checks. [[1]](diffhunk://#diff-f5807bec4aea2b1160a8d83779153d82696ff5c2fe8012c7296beb6be1ff996bR1-R56) [[2]](diffhunk://#diff-4de4d8adaab2abc89a98548d231b8a2a7745653487edd8293d23a56d1fd2213aR67-R80) [[3]](diffhunk://#diff-4de4d8adaab2abc89a98548d231b8a2a7745653487edd8293d23a56d1fd2213aR91) [[4]](diffhunk://#diff-9579b456a75840b8850bee0df6ee879dae45aece51228510c2556c5ad5f85135R1-R34)